### PR TITLE
Added animal damage flag

### DIFF
--- a/src/main/java/com/sk89q/worldguard/bukkit/listener/RegionProtectionListener.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/listener/RegionProtectionListener.java
@@ -469,7 +469,7 @@ public class RegionProtectionListener extends AbstractListener {
 
         /* Everything else */
         } else {
-            canDamage = query.testBuild(target, associable, combine(event, DefaultFlag.INTERACT));
+            canDamage = query.testBuild(target, associable, combine(event, DefaultFlag.ENTITY_DAMAGE));
             what = "hit that";
         }
 

--- a/src/main/java/com/sk89q/worldguard/protection/flags/DefaultFlag.java
+++ b/src/main/java/com/sk89q/worldguard/protection/flags/DefaultFlag.java
@@ -49,6 +49,7 @@ public final class DefaultFlag {
     public static final StateFlag BLOCK_PLACE = new StateFlag("block-place", false);
     public static final StateFlag USE = new StateFlag("use", false);
     public static final StateFlag INTERACT = new StateFlag("interact", false);
+    public static final StateFlag ENTITY_DAMAGE = new StateFlag("entity-damage", true);
     public static final StateFlag PVP = new StateFlag("pvp", false);
     public static final StateFlag SLEEP = new StateFlag("sleep", false);
     public static final StateFlag TNT = new StateFlag("tnt", false);
@@ -153,7 +154,7 @@ public final class DefaultFlag {
             MUSHROOMS, LEAF_DECAY, GRASS_SPREAD, MYCELIUM_SPREAD, VINE_GROWTH,
             SEND_CHAT, RECEIVE_CHAT, FIRE_SPREAD, LAVA_FIRE, LAVA_FLOW, WATER_FLOW,
             TELE_LOC, SPAWN_LOC, POTION_SPLASH, TIME_LOCK, WEATHER_LOCK,
-            BLOCKED_CMDS, ALLOWED_CMDS, PRICE, BUYABLE, ENABLE_SHOP
+            BLOCKED_CMDS, ALLOWED_CMDS, PRICE, BUYABLE, ENABLE_SHOP, ENTITY_DAMAGE
     };
 
     private DefaultFlag() {


### PR DESCRIPTION
Due to the latest 6.0 changes we had the problem that users could no longer damage entities, which they could before. We saw that this was checked by the interact flag, but enabling this one globally would cause other bigger problems.
Basically we're running with a global build deny, having cities and inner user zones with special build flags. Thus we just needed to be able to allow entity damage again. So I thought adding a special flag should be the right way!