### PR TITLE
Make RegionPrintoutBuilder use the FlagRegistry

### DIFF
--- a/src/main/java/com/sk89q/worldguard/bukkit/commands/region/RegionPrintoutBuilder.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/commands/region/RegionPrintoutBuilder.java
@@ -21,10 +21,12 @@ package com.sk89q.worldguard.bukkit.commands.region;
 
 import com.sk89q.squirrelid.cache.ProfileCache;
 import com.sk89q.worldedit.BlockVector;
+import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
 import com.sk89q.worldguard.domains.DefaultDomain;
 import com.sk89q.worldguard.protection.flags.DefaultFlag;
 import com.sk89q.worldguard.protection.flags.Flag;
 import com.sk89q.worldguard.protection.flags.RegionGroupFlag;
+import com.sk89q.worldguard.protection.flags.registry.FlagRegistry;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -105,7 +107,7 @@ public class RegionPrintoutBuilder implements Callable<String> {
     public void appendFlagsList(boolean useColors) {
         boolean hasFlags = false;
         
-        for (Flag<?> flag : DefaultFlag.getFlags()) {
+        for (Flag<?> flag : WorldGuardPlugin.inst().getFlagRegistry()) {
             Object val = region.getFlag(flag), group = null;
             
             // No value


### PR DESCRIPTION
Currently, when running ```/region info``` or any other command that lists a region flags, it will only show default flags. This simple PR changes that, by instead making it iterate over the FlagRegistry.

I'm not certain on what the standard is for getting the WorldGuardPlugin instance, please correct me if I'm wrong.