### PR TITLE
Add support for Armor stands in protected regions

### DIFF
--- a/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardEntityListener.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardEntityListener.java
@@ -540,6 +540,11 @@ public class WorldGuardEntityListener implements Listener {
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onCreatureSpawn(CreatureSpawnEvent event) {
         ConfigurationManager cfg = plugin.getGlobalStateManager();
+        
+        //Allow spawning of Armor Stands
+        if(event.getEntity() instanceof ArmorStand) {
+            return;
+        }
 
         if (cfg.activityHaltToggle) {
             event.setCancelled(true);


### PR DESCRIPTION
Add support for armor stands in regions with the "mob-spawning: deny" flag by cancelling the onCreatureSpawn method and therefor not preventing them to be spawned.