### PR TITLE
FEATURE OR FLAG ADJUSTMENT URGENT

### DIFF
--- a/src/main/java/com/sk89q/worldguard/bukkit/commands/region/RegionCommands.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/commands/region/RegionCommands.java
@@ -44,11 +44,7 @@ import com.sk89q.worldguard.bukkit.commands.task.RegionRemover;
 import com.sk89q.worldguard.bukkit.permission.RegionPermissionModel;
 import com.sk89q.worldguard.bukkit.util.logging.LoggerToChatHandler;
 import com.sk89q.worldguard.protection.ApplicableRegionSet;
-import com.sk89q.worldguard.protection.flags.DefaultFlag;
-import com.sk89q.worldguard.protection.flags.Flag;
-import com.sk89q.worldguard.protection.flags.InvalidFlagFormat;
-import com.sk89q.worldguard.protection.flags.RegionGroup;
-import com.sk89q.worldguard.protection.flags.RegionGroupFlag;
+import com.sk89q.worldguard.protection.flags.*;
 import com.sk89q.worldguard.protection.managers.RegionManager;
 import com.sk89q.worldguard.protection.managers.RemovalStrategy;
 import com.sk89q.worldguard.protection.managers.migration.DriverMigration;
@@ -536,7 +532,7 @@ public final class RegionCommands extends RegionCommandsBase {
             // Parse the [-g group] separately so entire command can abort if parsing
             // the [value] part throws an error.
             try {
-                groupValue = groupFlag.parseInput(plugin, sender, group);
+                groupValue = groupFlag.parseInput(FlagContext.create().setPlugin(plugin).setSender(sender).setInput(group).build());
             } catch (InvalidFlagFormat e) {
                 throw new CommandException(e.getMessage());
             }

--- a/src/main/java/com/sk89q/worldguard/bukkit/commands/region/RegionCommandsBase.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/commands/region/RegionCommandsBase.java
@@ -35,6 +35,8 @@ import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
 import com.sk89q.worldguard.bukkit.permission.RegionPermissionModel;
 import com.sk89q.worldguard.protection.ApplicableRegionSet;
 import com.sk89q.worldguard.protection.flags.Flag;
+import com.sk89q.worldguard.protection.flags.FlagContext;
+import com.sk89q.worldguard.protection.flags.FlagContext.FlagContextBuilder;
 import com.sk89q.worldguard.protection.flags.InvalidFlagFormat;
 import com.sk89q.worldguard.protection.managers.RegionManager;
 import com.sk89q.worldguard.protection.regions.GlobalProtectedRegion;
@@ -391,7 +393,8 @@ class RegionCommandsBase {
      * @throws InvalidFlagFormat thrown if the value is invalid
      */
     protected static <V> void setFlag(ProtectedRegion region, Flag<V> flag, CommandSender sender, String value) throws InvalidFlagFormat {
-        region.setFlag(flag, flag.parseInput(WorldGuardPlugin.inst(), sender, value));
+        region.setFlag(flag, flag.parseInput(FlagContext.create().setPlugin(WorldGuardPlugin.inst()).setRegion(region)
+                                                .setSender(sender).setInput(value).build()));
     }
 
 }

--- a/src/main/java/com/sk89q/worldguard/protection/flags/BooleanFlag.java
+++ b/src/main/java/com/sk89q/worldguard/protection/flags/BooleanFlag.java
@@ -37,8 +37,8 @@ public class BooleanFlag extends Flag<Boolean> {
     }
 
     @Override
-    public Boolean parseInput(WorldGuardPlugin plugin, CommandSender sender, String input) throws InvalidFlagFormat {
-        input = input.trim();
+    public Boolean parseInput(FlagContext context) throws InvalidFlagFormat {
+        String input = context.getUserInput();
         
         if (input.equalsIgnoreCase("true") || input.equalsIgnoreCase("yes")
                 || input.equalsIgnoreCase("on")

--- a/src/main/java/com/sk89q/worldguard/protection/flags/CommandStringFlag.java
+++ b/src/main/java/com/sk89q/worldguard/protection/flags/CommandStringFlag.java
@@ -37,7 +37,8 @@ public class CommandStringFlag extends Flag<String> {
     }
 
     @Override
-    public String parseInput(WorldGuardPlugin plugin, CommandSender sender, String input) throws InvalidFlagFormat {
+    public String parseInput(FlagContext context) throws InvalidFlagFormat {
+        String input = context.getUserInput();
         input = input.trim();
         if (!input.startsWith("/")) {
             input = "/" + input;

--- a/src/main/java/com/sk89q/worldguard/protection/flags/DoubleFlag.java
+++ b/src/main/java/com/sk89q/worldguard/protection/flags/DoubleFlag.java
@@ -37,8 +37,8 @@ public class DoubleFlag extends Flag<Double> {
     }
 
     @Override
-    public Double parseInput(WorldGuardPlugin plugin, CommandSender sender, String input) throws InvalidFlagFormat {
-        input = input.trim();
+    public Double parseInput(FlagContext context) throws InvalidFlagFormat {
+        String input = context.getUserInput(); // TODO getDouble
 
         try {
             return Double.parseDouble(input);

--- a/src/main/java/com/sk89q/worldguard/protection/flags/EnumFlag.java
+++ b/src/main/java/com/sk89q/worldguard/protection/flags/EnumFlag.java
@@ -78,7 +78,8 @@ public class EnumFlag<T extends Enum<T>> extends Flag<T> {
     }
 
     @Override
-    public T parseInput(WorldGuardPlugin plugin, CommandSender sender, String input) throws InvalidFlagFormat {
+    public T parseInput(FlagContext context) throws InvalidFlagFormat {
+        String input = context.getString("input");
         try {
             return findValue(input);
         } catch (IllegalArgumentException e) {

--- a/src/main/java/com/sk89q/worldguard/protection/flags/Flag.java
+++ b/src/main/java/com/sk89q/worldguard/protection/flags/Flag.java
@@ -152,13 +152,11 @@ public abstract class Flag<T> {
     /**
      * Parse a given input to coerce it to a type compatible with the flag.
      *
-     * @param plugin The plugin
-     * @param sender The sender
-     * @param input THe input
+     * @param context the {@link FlagContext}
      * @return The coerced type
      * @throws InvalidFlagFormat Raised if the input is invalid
      */
-    public abstract T parseInput(WorldGuardPlugin plugin, CommandSender sender, String input) throws InvalidFlagFormat;
+    public abstract T parseInput(FlagContext context) throws InvalidFlagFormat;
 
     /**
      * Convert a raw type that was loaded (from a YAML file, for example)

--- a/src/main/java/com/sk89q/worldguard/protection/flags/FlagContext.java
+++ b/src/main/java/com/sk89q/worldguard/protection/flags/FlagContext.java
@@ -1,0 +1,121 @@
+/*
+ * WorldGuard, a suite of tools for Minecraft
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldGuard team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldguard.protection.flags;
+
+import com.google.common.collect.Maps;
+import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
+import com.sk89q.worldguard.protection.regions.ProtectedRegion;
+import org.bukkit.command.CommandSender;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+
+public class FlagContext {
+
+    private Map<String, Object> context = Maps.newHashMap();
+
+    public static FlagContextBuilder create() {
+        return new FlagContextBuilder();
+    }
+
+    public void put(String name, Object value) {
+        context.put(name, value);
+    }
+
+    public String getString(String name) throws InvalidFlagFormat {
+        Object val = get(name);
+        if (val == null) return null;
+        return (val instanceof String ? ((String) val).trim() : val.toString());
+    }
+
+    public String getUserInput() throws InvalidFlagFormat {
+        return getString("input");
+    }
+
+    public CommandSender getSender() throws InvalidFlagFormat {
+        Object val = get("sender");
+        if (val == null) throw new InvalidFlagFormat("Missing CommandSender!");
+        if (val instanceof CommandSender) {
+            return ((CommandSender) val);
+        } else {
+            throw new InvalidFlagFormat("Sender is an impostor!");
+        }
+    }
+
+    public Integer getInt(String name) throws InvalidFlagFormat {
+        Object val = get(name);
+        if (val == null) return null;
+        try {
+            return Integer.valueOf(((String) val).trim());
+        } catch (NumberFormatException e) {
+            throw new InvalidFlagFormat("Expected number for " + name + ", but got " + val);
+        }
+    }
+
+    @Nullable
+    public Object get(String name) {
+        return get(name, null);
+    }
+
+    @Nullable
+    public Object get(String name, Object defaultValue) {
+        return context.getOrDefault(name, defaultValue);
+    }
+
+    public FlagContext copy() {
+        FlagContext clone = new FlagContext();
+        clone.context.putAll(this.context);
+        return clone;
+    }
+
+    public static class FlagContextBuilder {
+
+        private FlagContext context;
+
+        public FlagContextBuilder() {
+            this.context = new FlagContext();
+        }
+
+        // TODO do we even need this? everything just uses WorldGuardPlugin.inst() anyway
+        public FlagContextBuilder setPlugin(WorldGuardPlugin plugin) {
+            context.put("plugin", plugin);
+            return this;
+        }
+
+        public FlagContextBuilder setSender(CommandSender sender) {
+            context.put("sender", sender);
+            return this;
+        }
+
+        public FlagContextBuilder setInput(String input) {
+            context.put("input", input);
+            return this;
+        }
+
+        public FlagContextBuilder setRegion(ProtectedRegion region) {
+            context.put("region", region);
+            return this;
+        }
+
+        public FlagContext build() {
+            return context;
+        }
+    }
+}

--- a/src/main/java/com/sk89q/worldguard/protection/flags/IntegerFlag.java
+++ b/src/main/java/com/sk89q/worldguard/protection/flags/IntegerFlag.java
@@ -37,14 +37,8 @@ public class IntegerFlag extends Flag<Integer> {
     }
 
     @Override
-    public Integer parseInput(WorldGuardPlugin plugin, CommandSender sender,String input) throws InvalidFlagFormat {
-        input = input.trim();
-
-        try {
-            return Integer.parseInt(input);
-        } catch (NumberFormatException e) {
-            throw new InvalidFlagFormat("Not a number: " + input);
-        }
+    public Integer parseInput(FlagContext context) throws InvalidFlagFormat {
+        return context.getInt("input");
     }
 
     @Override

--- a/src/main/java/com/sk89q/worldguard/protection/flags/LocationFlag.java
+++ b/src/main/java/com/sk89q/worldguard/protection/flags/LocationFlag.java
@@ -42,12 +42,12 @@ public class LocationFlag extends Flag<Location> {
     }
 
     @Override
-    public Location parseInput(WorldGuardPlugin plugin, CommandSender sender, String input) throws InvalidFlagFormat {
-        input = input.trim();
+    public Location parseInput(FlagContext context) throws InvalidFlagFormat {
+        String input = context.getUserInput(); // todo make a getLocation
 
         final Player player;
         try {
-            player = plugin.checkPlayer(sender);
+            player = WorldGuardPlugin.inst().checkPlayer(((CommandSender) context.get("sender")));
         } catch (CommandException e) {
             throw new InvalidFlagFormat(e.getMessage());
         }

--- a/src/main/java/com/sk89q/worldguard/protection/flags/SetFlag.java
+++ b/src/main/java/com/sk89q/worldguard/protection/flags/SetFlag.java
@@ -56,14 +56,17 @@ public class SetFlag<T> extends Flag<Set<T>> {
     }
 
     @Override
-    public Set<T> parseInput(WorldGuardPlugin plugin, CommandSender sender, String input) throws InvalidFlagFormat {
+    public Set<T> parseInput(FlagContext context) throws InvalidFlagFormat {
+        String input = context.getUserInput();
         if (input.isEmpty()) {
             return Sets.newHashSet();
         } else {
             Set<T> items = Sets.newHashSet();
 
             for (String str : input.split(",")) {
-                items.add(subFlag.parseInput(plugin, sender, str.trim()));
+                FlagContext copy = context.copy();
+                copy.put("input", str);
+                items.add(subFlag.parseInput(copy));
             }
 
             return items;

--- a/src/main/java/com/sk89q/worldguard/protection/flags/StateFlag.java
+++ b/src/main/java/com/sk89q/worldguard/protection/flags/StateFlag.java
@@ -81,8 +81,8 @@ public class StateFlag extends Flag<StateFlag.State> {
     }
 
     @Override
-    public State parseInput(WorldGuardPlugin plugin, CommandSender sender, String input) throws InvalidFlagFormat {
-        input = input.trim();
+    public State parseInput(FlagContext context) throws InvalidFlagFormat {
+        String input = context.getUserInput();
 
         if (input.equalsIgnoreCase("allow")) {
             return State.ALLOW;

--- a/src/main/java/com/sk89q/worldguard/protection/flags/StringFlag.java
+++ b/src/main/java/com/sk89q/worldguard/protection/flags/StringFlag.java
@@ -59,8 +59,8 @@ public class StringFlag extends Flag<String> {
     }
 
     @Override
-    public String parseInput(WorldGuardPlugin plugin, CommandSender sender, String input) throws InvalidFlagFormat {
-        return input.replaceAll("(?!\\\\)\\\\n", "\n").replaceAll("\\\\\\\\n", "\\n");
+    public String parseInput(FlagContext context) throws InvalidFlagFormat {
+        return context.getUserInput().replaceAll("(?!\\\\)\\\\n", "\n").replaceAll("\\\\\\\\n", "\\n");
     }
 
     @Override

--- a/src/main/java/com/sk89q/worldguard/protection/flags/VectorFlag.java
+++ b/src/main/java/com/sk89q/worldguard/protection/flags/VectorFlag.java
@@ -42,12 +42,12 @@ public class VectorFlag extends Flag<Vector> {
     }
 
     @Override
-    public Vector parseInput(WorldGuardPlugin plugin, CommandSender sender, String input) throws InvalidFlagFormat {
-        input = input.trim();
+    public Vector parseInput(FlagContext context) throws InvalidFlagFormat {
+        String input = context.getUserInput(); // todo make a getLocation
 
         if ("here".equalsIgnoreCase(input)) {
             try {
-                return BukkitUtil.toVector(plugin.checkPlayer(sender).getLocation());
+                return BukkitUtil.toVector(WorldGuardPlugin.inst().checkPlayer(((CommandSender) context.get("sender"))).getLocation());
             } catch (CommandException e) {
                 throw new InvalidFlagFormat(e.getMessage());
             }


### PR DESCRIPTION
Please make the PVP flag respect the outside and inside of the region, meaning i create a region then flag it as pvp allow. then restrict players to harm another player when inside the region. Right now players outside the region can do damage to the players inside the pvp region. suggestion put a check if the source attacking player is inside the same region if true then allow the event if false cancel the event and say "your are not allowed to pvp here" 