### PR TITLE
Added experimental custom flag support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 6.1
 
+* Added experimental custom flag support
 * Added `exit-via-teleport` flag (default allow) to control exiting an exit=deny region via teleportation.
 * Added a `fall-damage` flag to control player damage caused by falling.
 * Added a `time-lock` flag to lock players' time of day. Valid values are from 0 to 24000 for absolute time, or +- any number for relative time.

--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPlugin.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPlugin.java
@@ -40,6 +40,9 @@ import com.sk89q.worldguard.bukkit.event.player.ProcessPlayerEvent;
 import com.sk89q.worldguard.bukkit.listener.*;
 import com.sk89q.worldguard.bukkit.util.Events;
 import com.sk89q.worldguard.protection.GlobalRegionManager;
+import com.sk89q.worldguard.protection.flags.CustomFlagBroker;
+import com.sk89q.worldguard.protection.flags.CustomFlagBrokerImpl;
+import com.sk89q.worldguard.protection.flags.CustomFlagProvider;
 import com.sk89q.worldguard.protection.flags.Flag;
 import com.sk89q.worldguard.protection.managers.RegionManager;
 import com.sk89q.worldguard.protection.managers.storage.StorageException;
@@ -129,6 +132,19 @@ public class WorldGuardPlugin extends JavaPlugin {
         configureLogger();
 
         getDataFolder().mkdirs(); // Need to create the plugins/WorldGuard folder
+        
+        // Load in custom flags
+        for (Plugin plugin : this.getServer().getPluginManager().getPlugins()) {
+            CustomFlagBroker broker = new CustomFlagBrokerImpl();
+            if (plugin instanceof CustomFlagProvider) {
+                CustomFlagProvider provider = (CustomFlagProvider)plugin;
+                try {
+                    provider.addCustomFlags(broker);
+                } catch (Exception e) {
+                    // Ignore
+                }
+            }
+        }
 
         executorService = MoreExecutors.listeningDecorator(EvenMoreExecutors.newBoundedCachedThreadPool(0, 1, 20));
 

--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPlugin.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPlugin.java
@@ -131,20 +131,20 @@ public class WorldGuardPlugin extends JavaPlugin {
     public void onEnable() {
         configureLogger();
 
-        getDataFolder().mkdirs(); // Need to create the plugins/WorldGuard folder
-        
         // Load in custom flags
+        CustomFlagBroker broker = new CustomFlagBrokerImpl();
         for (Plugin plugin : this.getServer().getPluginManager().getPlugins()) {
-            CustomFlagBroker broker = new CustomFlagBrokerImpl();
             if (plugin instanceof CustomFlagProvider) {
                 CustomFlagProvider provider = (CustomFlagProvider)plugin;
                 try {
                     provider.addCustomFlags(broker);
                 } catch (Exception e) {
-                    // Ignore
+                    log.log(Level.WARNING, "Unhandled exception from plugin \"" + plugin + "\"", e);
                 }
             }
         }
+
+        getDataFolder().mkdirs(); // Need to create the plugins/WorldGuard folder
 
         executorService = MoreExecutors.listeningDecorator(EvenMoreExecutors.newBoundedCachedThreadPool(0, 1, 20));
 

--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/protection/flags/CustomFlagBroker.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/protection/flags/CustomFlagBroker.java
@@ -21,10 +21,14 @@ package com.sk89q.worldguard.protection.flags;
 
 /**
  * Use this object to add custom flags to world guard.
- * 
- * @author Challenger2
  *
  */
 public interface CustomFlagBroker {
+    
+    /**
+     * Add a custom flag to WorldGuard
+     * 
+     * @param flag A flag to add
+     */
     public void addFlag(Flag<?> flag);
 }

--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/protection/flags/CustomFlagBroker.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/protection/flags/CustomFlagBroker.java
@@ -1,0 +1,30 @@
+/*
+ * WorldGuard, a suite of tools for Minecraft
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldGuard team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldguard.protection.flags;
+
+/**
+ * Use this object to add custom flags to world guard.
+ * 
+ * @author Challenger2
+ *
+ */
+public interface CustomFlagBroker {
+    public void addFlag(Flag<?> flag);
+}

--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/protection/flags/CustomFlagBrokerImpl.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/protection/flags/CustomFlagBrokerImpl.java
@@ -1,0 +1,28 @@
+/*
+ * WorldGuard, a suite of tools for Minecraft
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldGuard team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldguard.protection.flags;
+
+public class CustomFlagBrokerImpl implements CustomFlagBroker {
+
+    @Override
+    public void addFlag(Flag<?> flag) {
+        DefaultFlag.addFlag(flag);
+    }
+}

--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/protection/flags/CustomFlagProvider.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/protection/flags/CustomFlagProvider.java
@@ -36,5 +36,12 @@ package com.sk89q.worldguard.protection.flags;
  */
 public interface CustomFlagProvider {
 
+    /**
+     * addCustomFlags is called just after WorldGuard first loads. All plugins
+     * implementing this interface will be notified to add customfalgs
+     * at this time.
+     * 
+     * @param broker An object that can be used to add custom flags.
+     */
     public void addCustomFlags(CustomFlagBroker broker);
 }

--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/protection/flags/CustomFlagProvider.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/protection/flags/CustomFlagProvider.java
@@ -1,0 +1,40 @@
+/*
+ * WorldGuard, a suite of tools for Minecraft
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldGuard team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.sk89q.worldguard.protection.flags;
+
+/**
+ * 
+ * Bucket plugins that need to use custom world guard flags should implement
+ * this interface. World Guard will invoke the addCustomFlags method on every
+ * plugin that implements this when world guard's "onEnable" is called.
+ * 
+ * Plugin's can then use the provided broker object to add custom flags. Plugins
+ * should add custom flags only, and not attempt to access bukkit or world
+ * edit APIs, are all of the plugins have not been loaded yet.
+ * 
+ * Every plugins "onLoad()" will be called before addCustomFlags() is called, but
+ * this could be before or after "onEnable()" is called.
+ * 
+ * @author Challenger2
+ *
+ */
+public interface CustomFlagProvider {
+
+    public void addCustomFlags(CustomFlagBroker broker);
+}

--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/protection/flags/DefaultFlag.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/protection/flags/DefaultFlag.java
@@ -19,16 +19,10 @@
 
 package com.sk89q.worldguard.protection.flags;
 
-import java.util.Arrays;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
 import org.bukkit.WeatherType;
 import org.bukkit.entity.EntityType;
-
-import com.sk89q.worldguard.bukkit.commands.region.RegionCommands;
 
 /**
  * The flags that are used in WorldGuard.
@@ -162,10 +156,6 @@ public final class DefaultFlag {
             TELE_LOC, SPAWN_LOC, POTION_SPLASH, TIME_LOCK, WEATHER_LOCK,
             BLOCKED_CMDS, ALLOWED_CMDS, PRICE, BUYABLE, ENABLE_SHOP
     };
-    
-    
-    // Remember if we have unlocked the flag field with reflection
-    private static boolean addFlagsUnlocked = false;
 
     private DefaultFlag() {
     }
@@ -188,37 +178,5 @@ public final class DefaultFlag {
         }
 
         return null;
-    }
-
-    /**
-     * Add a new custom flag to the flags list
-     *
-     * @param flag The flag to add
-     */
-    static void addFlag(Flag<?> flag) {
-        Flag<?> match = fuzzyMatchFlag(flag.getName());
-        if (match != null) {
-            throw new IllegalArgumentException("Duplicate flag");
-        }
-        Flag<?>[] newList = Arrays.copyOf(flagsList, flagsList.length + 1);
-        newList[flagsList.length] = flag;
-
-        // Force update the flagsList
-        // flagsList has to be public to allow other packages to access it, yet
-        // we have to be able to change it too :/
-        try {
-            java.lang.reflect.Field field = DefaultFlag.class.getField("flagsList");
-            if (!addFlagsUnlocked) {
-                addFlagsUnlocked = true;
-                java.lang.reflect.Field modifiersField = java.lang.reflect.Field.class.getDeclaredField("modifiers");
-                modifiersField.setAccessible(true);
-                modifiersField.setInt(field, field.getModifiers() & ~java.lang.reflect.Modifier.FINAL);
-            }
-            field.set(null, newList);
-        } catch (Exception e) {
-            Logger log = Logger.getLogger(DefaultFlag.class.getCanonicalName());
-            log.log(Level.WARNING, "Failed to add a custom flag", e);
-            throw new RuntimeException("Internel Error", e);
-        }
     }
 }

--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/protection/flags/DefaultFlag.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/protection/flags/DefaultFlag.java
@@ -19,10 +19,16 @@
 
 package com.sk89q.worldguard.protection.flags;
 
+import java.util.Arrays;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
 import org.bukkit.WeatherType;
 import org.bukkit.entity.EntityType;
+
+import com.sk89q.worldguard.bukkit.commands.region.RegionCommands;
 
 /**
  * The flags that are used in WorldGuard.
@@ -156,6 +162,10 @@ public final class DefaultFlag {
             TELE_LOC, SPAWN_LOC, POTION_SPLASH, TIME_LOCK, WEATHER_LOCK,
             BLOCKED_CMDS, ALLOWED_CMDS, PRICE, BUYABLE, ENABLE_SHOP
     };
+    
+    
+    // Remember if we have unlocked the flag field with reflection
+    private static boolean addFlagsUnlocked = false;
 
     private DefaultFlag() {
     }
@@ -178,5 +188,37 @@ public final class DefaultFlag {
         }
 
         return null;
+    }
+
+    /**
+     * Add a new custom flag to the flags list
+     *
+     * @param flag The flag to add
+     */
+    static void addFlag(Flag<?> flag) {
+        Flag<?> match = fuzzyMatchFlag(flag.getName());
+        if (match != null) {
+            throw new IllegalArgumentException("Duplicate flag");
+        }
+        Flag<?>[] newList = Arrays.copyOf(flagsList, flagsList.length + 1);
+        newList[flagsList.length] = flag;
+
+        // Force update the flagsList
+        // flagsList has to be public to allow other packages to access it, yet
+        // we have to be able to change it too :/
+        try {
+            java.lang.reflect.Field field = DefaultFlag.class.getField("flagsList");
+            if (!addFlagsUnlocked) {
+                addFlagsUnlocked = true;
+                java.lang.reflect.Field modifiersField = java.lang.reflect.Field.class.getDeclaredField("modifiers");
+                modifiersField.setAccessible(true);
+                modifiersField.setInt(field, field.getModifiers() & ~java.lang.reflect.Modifier.FINAL);
+            }
+            field.set(null, newList);
+        } catch (Exception e) {
+            Logger log = Logger.getLogger(DefaultFlag.class.getCanonicalName());
+            log.log(Level.WARNING, "Failed to add a custom flag", e);
+            throw new RuntimeException("Internel Error", e);
+        }
     }
 }


### PR DESCRIPTION
The custom flags work as follows:

1. WorldGuard's onEnable() is called.

2. World Guard looks for any plugin that implements CustomFlagProvider

3. World Guard invokes addCustomFlags() on each found plugin

4. World Guard passes in a CustomFlagBroker.

5. The plugin calls CustmFlagBroker.addFlag to add any flags it needs

A plugins addFlag method will be called after onLoad(), but may be called
before onEnable().

If a plugin that adds custom flags fails to load or is removed, World Guard
will remove all of the custom flags from all regions.
(Perhaps this can be changed in the future)

The above procedure fixes certain problems with WGCustomFlags, where WGCustomFlags tries to update the WorldGuard flags at the same time WorldGuard is loading asynchronously. WGCustomFlags cannot inject flags after WorldGuard load but before WorldGuard loads in its files. This was the primary motivation to adding a CustomFlagProvider and allowing WorldGuard itself to solicit custom flags from plugins.
