### PR TITLE
Fix chorus-fruit-teleport flag behaviour

### DIFF
--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardPlayerListener.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardPlayerListener.java
@@ -386,6 +386,12 @@ public class WorldGuardPlayerListener implements Listener {
                         event.setCancelled(true);
                         return;
                     }
+                    if (!plugin.getGlobalRegionManager().hasBypass(localPlayer, world)
+                            && !(set.allows(DefaultFlag.CHORUS_TELEPORT, localPlayer))) {
+                        player.sendMessage(ChatColor.DARK_RED + "You're not allowed to teleport there.");
+                        event.setCancelled(true);
+                        return;
+                    }
                 }
             } catch (NoSuchFieldError ignored) {}
         }


### PR DESCRIPTION
This pull request fixes the behaviour of the chorus fruit flag to better protect against chorus fruit teleportation by using a similar way to the enderpearl flag behaviour: it adds a check to stop players from teleporting inside of regions with the chorus-fruit-teleport flag set to deny.