### PR TITLE
Adds simple transient ProtectedRegion functionality

### DIFF
--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/protection/managers/RegionManager.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/protection/managers/RegionManager.java
@@ -107,7 +107,7 @@ public final class RegionManager {
      */
     public void save() throws StorageException {
         index.setDirty(false);
-        store.saveAll(new HashSet<ProtectedRegion>(getValuesCopy()));
+        store.saveAll(new HashSet<ProtectedRegion>(getFilteredValuesCopy()));
     }
 
     /**
@@ -424,12 +424,18 @@ public final class RegionManager {
     }
 
     /**
-     * Get an {@link ArrayList} copy of regions in the index.
+     * Get an {@link ArrayList} copy of regions in the index with transient regions filtered.
      *
      * @return a list
      */
-    private List<ProtectedRegion> getValuesCopy() {
-        return new ArrayList<ProtectedRegion>(index.values());
+    private List<ProtectedRegion> getFilteredValuesCopy() {
+        List<ProtectedRegion> filteredValues = new ArrayList<ProtectedRegion>();
+        for (ProtectedRegion region : index.values()) {
+            if (!region.isTransient()) {
+                filteredValues.add(region);
+            }
+        }
+        return filteredValues;
     }
 
     // =============== HELPER METHODS ===============

--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/protection/regions/GlobalProtectedRegion.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/protection/regions/GlobalProtectedRegion.java
@@ -39,12 +39,24 @@ import java.util.List;
 public class GlobalProtectedRegion extends ProtectedRegion {
 
     /**
-     * Create a new instance.
+     * Create a new instance.<br>
+     * Equivalent to {@link #GlobalProtectedRegion(String, boolean) GlobalProtectedRegion(id, false)}<br>
+     * <code>transientRegion</code> will be set to false, and this region can be saved.
      *
      * @param id the ID
      */
     public GlobalProtectedRegion(String id) {
-        super(id);
+        this(id, false);
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param id the ID
+     * @param transientRegion whether this region should only be kept in memory and not be saved
+     */
+    public GlobalProtectedRegion(String id, boolean transientRegion) {
+        super(id, transientRegion);
         min = new BlockVector(0, 0, 0);
         max = new BlockVector(0, 0, 0);
     }

--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedCuboidRegion.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedCuboidRegion.java
@@ -39,14 +39,29 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class ProtectedCuboidRegion extends ProtectedRegion {
 
     /**
-     * Construct a new instance of this cuboid region.
+     * Construct a new instance of this cuboid region.<br>
+     * Equivalent to {@link #ProtectedCuboidRegion(String, boolean, BlockVector, BlockVector)
+     * ProtectedCuboidRegion(id, false, pt1, pt2)}<br>
+     * <code>transientRegion</code> will be set to false, and this region can be saved.
      *
      * @param id the region id
      * @param pt1 the first point of this region
      * @param pt2 the second point of this region
      */
     public ProtectedCuboidRegion(String id, BlockVector pt1, BlockVector pt2) {
-        super(id);
+        this(id, false, pt1, pt2);
+    }
+
+    /**
+     * Construct a new instance of this cuboid region.
+     *
+     * @param id the region id
+     * @param transientRegion whether this region should only be kept in memory and not be saved
+     * @param pt1 the first point of this region
+     * @param pt2 the second point of this region
+     */
+    public ProtectedCuboidRegion(String id, boolean transientRegion, BlockVector pt1, BlockVector pt2) {
+        super(id, transientRegion);
         setMinMaxPoints(pt1, pt2);
     }
 

--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedPolygonalRegion.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedPolygonalRegion.java
@@ -36,8 +36,32 @@ public class ProtectedPolygonalRegion extends ProtectedRegion {
     private final int minY;
     private final int maxY;
 
+    /**
+     * Construct a new instance of this polygonal region.<br>
+     * Equivalent to {@link #ProtectedPolygonalRegion(String, boolean, List, int, int)
+     * ProtectedPolygonalRegion(id, false, points, minY, maxY)}<br>
+     * <code>transientRegion</code> will be set to false, and this region can be saved.
+     *
+     * @param id the region id
+     * @param points a {@link List} of points that this region should contain
+     * @param minY the minimum y coordinate
+     * @param maxY the maximum y coordinate
+     */
     public ProtectedPolygonalRegion(String id, List<BlockVector2D> points, int minY, int maxY) {
-        super(id);
+        this(id, false, points, minY, maxY);
+    }
+
+    /**
+     * Construct a new instance of this polygonal region.
+     *
+     * @param id the region id
+     * @param transientRegion whether this region should only be kept in memory and not be saved
+     * @param points a {@link List} of points that this region should contain
+     * @param minY the minimum y coordinate
+     * @param maxY the maximum y coordinate
+     */
+    public ProtectedPolygonalRegion(String id, boolean transientRegion, List<BlockVector2D> points, int minY, int maxY) {
+        super(id, transientRegion);
         ImmutableList<BlockVector2D> immutablePoints = ImmutableList.copyOf(points);
         setMinMaxPoints(immutablePoints, minY, maxY);
         this.points = immutablePoints;

--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedRegion.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedRegion.java
@@ -56,6 +56,7 @@ public abstract class ProtectedRegion implements ChangeTracked, Comparable<Prote
     protected BlockVector max;
 
     private final String id;
+    private final boolean transientRegion;
     private int priority = 0;
     private ProtectedRegion parent;
     private DefaultDomain owners = new DefaultDomain();
@@ -67,9 +68,10 @@ public abstract class ProtectedRegion implements ChangeTracked, Comparable<Prote
      * Construct a new instance of this region.
      *
      * @param id the name of this region
+     * @param transientRegion whether this region should only be kept in memory and not be saved
      * @throws IllegalArgumentException thrown if the ID is invalid (see {@link #isValidId(String)}
      */
-    ProtectedRegion(String id) { // Package private because we can't have people creating their own region types
+    ProtectedRegion(String id, boolean transientRegion) { // Package private because we can't have people creating their own region types
         checkNotNull(id);
 
         if (!isValidId(id)) {
@@ -77,6 +79,7 @@ public abstract class ProtectedRegion implements ChangeTracked, Comparable<Prote
         }
 
         this.id = Normal.normalize(id);
+        this.transientRegion = transientRegion;
     }
 
     /**
@@ -680,8 +683,21 @@ public abstract class ProtectedRegion implements ChangeTracked, Comparable<Prote
      */
     abstract Area toArea();
 
+    /**
+     * @return <code>true</code> if this region should only be kept in memory and not be saved
+     */
+    public boolean isTransient() {
+        return transientRegion;
+    }
+
+    /**
+     * @return <code>true</code> if this region is not transient and changes have been made.
+     */
     @Override
     public boolean isDirty() {
+        if (isTransient()) {
+            return false;
+        }
         return dirty || owners.isDirty() || members.isDirty();
     }
 


### PR DESCRIPTION
This PR adds a final boolean property named "transientRegion" to ProtectedRegion as a flag to indicate that the region should only be stored in memory and not saved.
All ProtectedRegion subclasses have an overloaded constructor with the additional transientRegion parameter to allow regions to be marked as transient upon construction.  No existing method or constructor signature was changed.
A transient check in isDirty() is needed so saveChanges() does not include transient regions.
This is tested and working as expected.

**Note:** this PR is a re-submission of PR https://github.com/sk89q/WorldGuard/pull/335 from a clean fork since that PR became very stale and was too much of a mess to rebase and squash.  Refer to the original PR for the previous conversation.