### PR TITLE
Fix Materials.ARMOR_STAND being null in 1.8.

### DIFF
--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/util/Materials.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/util/Materials.java
@@ -54,10 +54,7 @@ public final class Materials {
             // for backwards compatible access to material enum
             ARMOR_STAND = Material.ARMOR_STAND;
             END_CRYSTAL = Material.END_CRYSTAL;
-        } catch (NoSuchFieldError ignored) {
-            ARMOR_STAND = null;
-            END_CRYSTAL = null;
-        }
+        } catch (NoSuchFieldError ignored) {}
 
         ENTITY_ITEMS.put(EntityType.PAINTING, Material.PAINTING);
         ENTITY_ITEMS.put(EntityType.ARROW, Material.ARROW);


### PR DESCRIPTION
In 1.8 Materials.ARMOR_STAND is null because END_CRYSTAL throws NoSuchFieldError and in the catch block ARMOR_STAND is set to null. This causes side effects such as players being able to place armor stands in protected regions.