### PR TITLE
Add support for Minecraft 1.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
     configurations.all {
         resolutionStrategy {
-            force 'com.google.guava:guava:17.0'
+            force 'com.google.guava:guava:21.0'
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,8 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.1'
-        classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:3.0.1'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.3'
+        classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.4.16'
         classpath 'org.ajoberstar:gradle-git:0.12.0'
     }
 }
@@ -50,7 +50,7 @@ subprojects {
     apply plugin: 'maven'
     apply plugin: 'checkstyle'
     apply plugin: 'com.github.johnrengelman.shadow'
-    apply plugin: 'com.jfrog.artifactory-upload'
+    apply plugin: 'com.jfrog.artifactory'
 
     group = 'com.sk89q.worldguard'
     version = '7.0.0-SNAPSHOT'

--- a/worldguard-legacy/build.gradle
+++ b/worldguard-legacy/build.gradle
@@ -4,17 +4,16 @@ apply plugin: 'idea'
 project.version = '6.2.1-SNAPSHOT'
 ext.internalVersion = project.version + ";" + gitCommitHash
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 checkstyle.configFile = new File(projectDir, "config/checkstyle/checkstyle.xml")
 
 dependencies {
     compile 'org.khelekore:prtree:1.5.0'
     compile 'org.bukkit:bukkit:1.11-R0.1-SNAPSHOT'
-    compile 'com.sk89q.worldedit:worldedit-bukkit:6.1.3-SNAPSHOT'
+    compile 'com.sk89q.worldedit:worldedit-bukkit:6.1.7-SNAPSHOT'
     compile 'com.sk89q:squirrelid:0.1.0'
-    compile 'com.sk89q:guavabackport:1.1'
     compile 'org.flywaydb:flyway-core:3.0'
     compile ('com.sk89q:commandbook:2.3') {
         exclude group: 'com.sk89q', module: 'worldedit'
@@ -41,14 +40,12 @@ processResources {
 shadowJar {
     dependencies {
         include(dependency('org.khelekore:prtree:1.5.0'))
-        include(dependency('com.sk89q:guavabackport:1.1'))
         include(dependency('com.sk89q:squirrelid:0.1.0'))
         include(dependency('org.flywaydb:flyway-core:3.0'))
         include(dependency('com.googlecode.json-simple:json-simple:1.1.1'))
         include(dependency('net.sf.opencsv:opencsv:2.0'))
     }
 
-    relocate('com.sk89q.guavabackport', 'com.sk89q.worldguard.internal.guava')
     relocate('org.flywaydb', 'com.sk89q.worldguard.internal.flywaydb')
     relocate('com.sk89q.squirrelid', 'com.sk89q.worldguard.util.profile')
     relocate('org.json.simple', 'com.sk89q.worldguard.util.jsonsimple')

--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/blacklist/Blacklist.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/blacklist/Blacklist.java
@@ -19,6 +19,9 @@
 
 package com.sk89q.worldguard.blacklist;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.sk89q.worldguard.blacklist.action.Action;
 import com.sk89q.worldguard.blacklist.action.ActionType;
 import com.sk89q.worldguard.blacklist.event.BlacklistEvent;
@@ -26,9 +29,6 @@ import com.sk89q.worldguard.blacklist.event.EventType;
 import com.sk89q.worldguard.blacklist.target.TargetMatcher;
 import com.sk89q.worldguard.blacklist.target.TargetMatcherParseException;
 import com.sk89q.worldguard.blacklist.target.TargetMatcherParser;
-import com.sk89q.guavabackport.cache.CacheBuilder;
-import com.sk89q.guavabackport.cache.CacheLoader;
-import com.sk89q.guavabackport.cache.LoadingCache;
 import com.sk89q.worldguard.bukkit.commands.CommandUtils;
 import org.bukkit.ChatColor;
 

--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/blacklist/BlacklistEntry.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/blacklist/BlacklistEntry.java
@@ -19,11 +19,11 @@
 
 package com.sk89q.worldguard.blacklist;
 
+import com.google.common.cache.LoadingCache;
 import com.sk89q.worldguard.LocalPlayer;
 import com.sk89q.worldguard.blacklist.action.Action;
 import com.sk89q.worldguard.blacklist.action.ActionResult;
 import com.sk89q.worldguard.blacklist.event.BlacklistEvent;
-import com.sk89q.guavabackport.cache.LoadingCache;
 
 import javax.annotation.Nullable;
 import java.util.*;

--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/blacklist/target/TargetMatcherParser.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/blacklist/target/TargetMatcherParser.java
@@ -21,7 +21,7 @@ package com.sk89q.worldguard.blacklist.target;
 
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
-import com.sk89q.guavabackport.collect.Range;
+import com.google.common.collect.Range;
 import com.sk89q.worldedit.blocks.ItemType;
 import com.sk89q.worldguard.util.Enums;
 import org.bukkit.Material;

--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/commands/FutureProgressListener.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/commands/FutureProgressListener.java
@@ -49,7 +49,7 @@ public class FutureProgressListener implements Runnable {
     }
 
     public static void addProgressListener(ListenableFuture<?> future, CommandSender sender, String message) {
-        future.addListener(new FutureProgressListener(sender, message), MoreExecutors.sameThreadExecutor());
+        future.addListener(new FutureProgressListener(sender, message), MoreExecutors.directExecutor());
     }
 
 }

--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/commands/WorldGuardCommands.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/commands/WorldGuardCommands.java
@@ -204,7 +204,7 @@ public class WorldGuardCommands {
                     activeSampler = null;
                 }
             }
-        }, MoreExecutors.sameThreadExecutor());
+        }, MoreExecutors.directExecutor());
 
         Futures.addCallback(sampler.getFuture(), new FutureCallback<Sampler>() {
             @Override

--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/listener/debounce/EventDebounce.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/listener/debounce/EventDebounce.java
@@ -19,10 +19,10 @@
 
 package com.sk89q.worldguard.bukkit.listener.debounce;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.sk89q.worldguard.bukkit.util.Events;
-import com.sk89q.guavabackport.cache.CacheBuilder;
-import com.sk89q.guavabackport.cache.CacheLoader;
-import com.sk89q.guavabackport.cache.LoadingCache;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 

--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/listener/debounce/legacy/AbstractEventDebounce.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/listener/debounce/legacy/AbstractEventDebounce.java
@@ -19,10 +19,10 @@
 
 package com.sk89q.worldguard.bukkit.listener.debounce.legacy;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.sk89q.worldguard.bukkit.util.Events;
-import com.sk89q.guavabackport.cache.CacheBuilder;
-import com.sk89q.guavabackport.cache.CacheLoader;
-import com.sk89q.guavabackport.cache.LoadingCache;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 

--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/util/report/SchedulerReport.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/util/report/SchedulerReport.java
@@ -20,10 +20,10 @@
 package com.sk89q.worldguard.bukkit.util.report;
 
 import com.google.common.base.Optional;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.google.common.reflect.TypeToken;
-import com.sk89q.guavabackport.cache.CacheBuilder;
-import com.sk89q.guavabackport.cache.CacheLoader;
-import com.sk89q.guavabackport.cache.LoadingCache;
 import com.sk89q.worldguard.util.report.DataReport;
 import org.bukkit.Bukkit;
 import org.bukkit.scheduler.BukkitTask;

--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/protection/FailedLoadRegionSet.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/protection/FailedLoadRegionSet.java
@@ -20,7 +20,6 @@
 package com.sk89q.worldguard.protection;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterators;
 import com.sk89q.worldguard.LocalPlayer;
 import com.sk89q.worldguard.protection.association.RegionAssociable;
 import com.sk89q.worldguard.protection.flags.DefaultFlag;
@@ -102,7 +101,7 @@ public class FailedLoadRegionSet extends AbstractRegionSet {
 
     @Override
     public Iterator<ProtectedRegion> iterator() {
-        return Iterators.emptyIterator();
+        return Collections.emptyIterator();
     }
 
     /**

--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/protection/PermissiveRegionSet.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/protection/PermissiveRegionSet.java
@@ -20,7 +20,6 @@
 package com.sk89q.worldguard.protection;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterators;
 import com.sk89q.worldguard.LocalPlayer;
 import com.sk89q.worldguard.protection.association.RegionAssociable;
 import com.sk89q.worldguard.protection.flags.DefaultFlag;
@@ -93,7 +92,7 @@ public class PermissiveRegionSet extends AbstractRegionSet {
 
     @Override
     public Iterator<ProtectedRegion> iterator() {
-        return Iterators.emptyIterator();
+        return Collections.emptyIterator();
     }
 
     /**

--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/session/SessionManager.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/session/SessionManager.java
@@ -19,9 +19,9 @@
 
 package com.sk89q.worldguard.session;
 
-import com.sk89q.guavabackport.cache.CacheBuilder;
-import com.sk89q.guavabackport.cache.CacheLoader;
-import com.sk89q.guavabackport.cache.LoadingCache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.sk89q.worldguard.bukkit.BukkitUtil;
 import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
 import com.sk89q.worldguard.session.handler.*;

--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/util/task/SimpleSupervisor.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/util/task/SimpleSupervisor.java
@@ -56,7 +56,7 @@ public class SimpleSupervisor implements Supervisor {
                     monitored.remove(task);
                 }
             }
-        }, MoreExecutors.sameThreadExecutor());
+        }, MoreExecutors.directExecutor());
     }
 
 }


### PR DESCRIPTION
Minecraft 1.12 requires Java 8 and bundles Guava 21. This and the associated WorldEdit changes allow usage in that scenario. Unfortunately it's hard/impossible to avoid breakage as Mojang jumped over two years of Guava versions, which is longer than their deprecation cycle.