### PR TITLE
Update WorldGuardPlayerListener.java

### DIFF
--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardPlayerListener.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardPlayerListener.java
@@ -440,7 +440,7 @@ public class WorldGuardPlayerListener implements Listener {
         }
     }
 
-    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onPlayerCommandPreprocess(PlayerCommandPreprocessEvent event) {
         Player player = event.getPlayer();
         LocalPlayer localPlayer = plugin.wrapPlayer(player);


### PR DESCRIPTION
A new essentials (?) update broke the command blocking system.

This update is required to allow worldguard to block Essentials commands.