### PR TITLE
Blacklist: Lava bug(see picture)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,29 @@
+5.9
+- Added a config option to allow explosion flags to only prevent block damage
+- Added allow-tamed-spawns setting, on by default. This will stop WorldGuard
+    from culling tamed animals.
+- Added config option and flag to prevent soil from drying naturally.
+- Added formatting codes, &k/l/m/n/o and &x (reset).
+- Added snow-fall-blocks option to config to restrict snow fall to certain blocks
+- Allow players to add newlines (\n) via command, not just manually in yml.
+- Allow the console to load/save all region managers with one command.
+- Changed entity report format slightly.
+- Check bypass perms for item-drop flag.
+- Check for entities and projectiles removing items from frames too.
+- Fix being able to use bonemeal to turn tall grass into double plants.
+- Fix number of arguments for migratedb command.
+- Fixed addowner/addmember commands adding command artifacts. Specifically, 
+    "-w <world>" will no longer be added when using it.
+- Fixed milking cows in protected areas due to changes in Bukkit.
+- Fixed ProtectedCuboidRegion::getPoints() returning points in wrong order.
+- Fixed snowman trails being treated as snow fall.
+- Make /rg list default to own regions if the player doesn't have permission otherwise.
+- Protected items in item frames in protected regions.
+- Resolved an issue where explosions of type OTHER_EXPLOSION were ignoring the world 
+    configuration settings.
+- Send item-use blacklist event when right-clicking entities.
+- Transformed the BlockFadeEvent handler into a switch.
+
 5.8:
 - BREAKING CHANGE: This version has been built for versions of Bukkit for MC 1.6.1 and
   newer. Do not try to use this version of WG on an older Bukkit version.

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.sk89q</groupId>
   <artifactId>worldguard</artifactId>
-  <version>5.9-SNAPSHOT</version>
+  <version>5.9</version>
   <packaging>jar</packaging>
   
   <!-- Project information -->
@@ -31,7 +31,7 @@
     <connection>scm:git:git://github.com/sk89q/worldguard.git</connection>
     <developerConnection>scm:git:git@github.com:sk89q/worldguard.git</developerConnection>
     <url>https://github.com/sk89q/worldguard</url>
-    <tag>master</tag>
+    <tag>5.9</tag>
   </scm>
   
   <mailingLists>
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>org.bukkit</groupId>
       <artifactId>bukkit</artifactId>
-      <version>1.6.2-R0.1-SNAPSHOT</version>
+      <version>1.7.2-R0.3</version>
       <scope>compile</scope>
       <type>jar</type>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.sk89q</groupId>
   <artifactId>worldguard</artifactId>
-  <version>5.8.1-SNAPSHOT</version>
+  <version>5.9</version>
   <packaging>jar</packaging>
   
   <!-- Project information -->

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.sk89q</groupId>
   <artifactId>worldguard</artifactId>
-  <version>5.9</version>
+  <version>5.9.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   
   <!-- Project information -->
@@ -31,7 +31,7 @@
     <connection>scm:git:git://github.com/sk89q/worldguard.git</connection>
     <developerConnection>scm:git:git@github.com:sk89q/worldguard.git</developerConnection>
     <url>https://github.com/sk89q/worldguard</url>
-    <tag>5.9</tag>
+    <tag>master</tag>
   </scm>
   
   <mailingLists>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.sk89q</groupId>
   <artifactId>worldguard</artifactId>
-  <version>5.9</version>
+  <version>5.9-SNAPSHOT</version>
   <packaging>jar</packaging>
   
   <!-- Project information -->

--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardEntityListener.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardEntityListener.java
@@ -70,6 +70,7 @@ import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.entity.PotionSplashEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
+import org.bukkit.projectiles.ProjectileSource;
 
 import com.sk89q.worldedit.Vector;
 import com.sk89q.worldedit.blocks.BlockID;
@@ -330,7 +331,7 @@ public class WorldGuardEntityListener implements Listener {
                         RegionManager mgr = plugin.getGlobalRegionManager().get(player.getWorld());
                         ApplicableRegionSet set = mgr.getApplicableRegions(pt);
                         if (fireball.getShooter() instanceof Player) {
-                            Vector pt2 = toVector(fireball.getShooter().getLocation());
+                            Vector pt2 = toVector(((Player) fireball.getShooter()).getLocation());
                             if (!mgr.getApplicableRegions(pt2).allows(DefaultFlag.PVP, plugin.wrapPlayer((Player) fireball.getShooter()))) {
                                 tryCancelPVPEvent((Player) fireball.getShooter(), player, event, true);
                             } else if (!set.allows(DefaultFlag.PVP, localPlayer)) {
@@ -399,7 +400,13 @@ public class WorldGuardEntityListener implements Listener {
 
     private void onEntityDamageByProjectile(EntityDamageByEntityEvent event) {
         Entity defender = event.getEntity();
-        Entity attacker = ((Projectile) event.getDamager()).getShooter();
+        Entity attacker;
+        ProjectileSource source = ((Projectile) event.getDamager()).getShooter();
+        if (source instanceof LivingEntity) {
+            attacker = (LivingEntity) source;
+        } else {
+            return;
+        }
 
         if (defender instanceof Player) {
             Player player = (Player) defender;

--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardHangingListener.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardHangingListener.java
@@ -28,6 +28,7 @@ import org.bukkit.entity.Creeper;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Hanging;
 import org.bukkit.entity.ItemFrame;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Painting;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
@@ -39,6 +40,7 @@ import org.bukkit.event.hanging.HangingBreakEvent;
 import org.bukkit.event.hanging.HangingBreakEvent.RemoveCause;
 import org.bukkit.event.hanging.HangingPlaceEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.projectiles.ProjectileSource;
 
 import com.sk89q.worldedit.blocks.ItemID;
 import com.sk89q.worldguard.blacklist.events.BlockBreakBlacklistEvent;
@@ -81,8 +83,9 @@ public class WorldGuardHangingListener implements Listener {
             HangingBreakByEntityEvent entityEvent = (HangingBreakByEntityEvent) event;
             Entity removerEntity = entityEvent.getRemover();
             if (removerEntity instanceof Projectile) {
-                Projectile projectile = (Projectile) removerEntity; 
-                removerEntity = projectile.getShooter() != null ? projectile.getShooter() : removerEntity; 
+                Projectile projectile = (Projectile) removerEntity;
+                ProjectileSource remover = projectile.getShooter(); 
+                removerEntity = (remover instanceof LivingEntity ? (LivingEntity) remover : null);
             }
 
             if (removerEntity instanceof Player) {
@@ -123,6 +126,8 @@ public class WorldGuardHangingListener implements Listener {
                     }
                 }
 
+                // this now covers dispensers as well, if removerEntity is null above,
+                // due to a non-LivingEntity ProjectileSource
                 if (hanging instanceof Painting
                         && (wcfg.blockEntityPaintingDestroy
                         || (wcfg.useRegions

--- a/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedPolygonalRegion.java
+++ b/src/main/java/com/sk89q/worldguard/protection/regions/ProtectedPolygonalRegion.java
@@ -154,7 +154,7 @@ public class ProtectedPolygonalRegion extends ProtectedRegion {
             p2 = points.get(s);
 
             // Do the math, then reassign s
-            area += ((p2.getBlockX() + .5) + (p1.getBlockX() + .5)) * ((p2.getBlockZ() + .5) - (p1.getBlockZ() + .5));
+            area += (p2.getBlockX() + p1.getBlockX() + 1) * (p2.getBlockZ() - p1.getBlockZ());
             s = i;
         }
         return (int) Math.abs(Math.ceil(area / 2D) * yLength);


### PR DESCRIPTION
if you put this in the blacklist.txt( https://worldguard.enginehub.org/en/latest/blacklist/ ) on a world:
[code]
[lavabucket]
ignore-groups=admins,mods
on-use=deny,tell
message=Sorry, you can't use lava buckets!
[/code]
and try to quickyl to put lava out of a bucket into water, you get this:
https://imgur.com/IifkzqH

Its optically in water, but not really. But irritating.

Console says nothing, Spigot 1.12.2, Worldguard: 6.2.1