### PR TITLE
Performence Issue on Teleport.

### DIFF
--- a/src/main/java/com/sk89q/worldguard/bukkit/RegionContainer.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/RegionContainer.java
@@ -85,7 +85,7 @@ public class RegionContainer {
      */
     void initialize() {
         ConfigurationManager config = plugin.getGlobalStateManager();
-        container = new RegionContainerImpl(config.selectedRegionStoreDriver);
+        container = new RegionContainerImpl(config.selectedRegionStoreDriver, plugin.getFlagRegistry());
 
         // Migrate to UUIDs
         autoMigrate();
@@ -293,7 +293,7 @@ public class RegionContainer {
 
         if (config.migrateRegionsToUuid) {
             RegionDriver driver = getDriver();
-            UUIDMigration migrator = new UUIDMigration(driver, plugin.getProfileService());
+            UUIDMigration migrator = new UUIDMigration(driver, plugin.getProfileService(), plugin.getFlagRegistry());
             migrator.setKeepUnresolvedNames(config.keepUnresolvedNames);
             try {
                 migrate(migrator);

--- a/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPlugin.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPlugin.java
@@ -39,6 +39,9 @@ import com.sk89q.worldguard.bukkit.event.player.ProcessPlayerEvent;
 import com.sk89q.worldguard.bukkit.listener.*;
 import com.sk89q.worldguard.bukkit.util.Events;
 import com.sk89q.worldguard.protection.GlobalRegionManager;
+import com.sk89q.worldguard.protection.flags.DefaultFlag;
+import com.sk89q.worldguard.protection.flags.registry.FlagRegistry;
+import com.sk89q.worldguard.protection.flags.registry.SimpleFlagRegistry;
 import com.sk89q.worldguard.protection.managers.RegionManager;
 import com.sk89q.worldguard.protection.managers.storage.StorageException;
 import com.sk89q.worldguard.protection.util.UnresolvedNamesException;
@@ -86,6 +89,7 @@ public class WorldGuardPlugin extends JavaPlugin {
     private final RegionContainer regionContainer = new RegionContainer(this);
     private final GlobalRegionManager globalRegionManager = new GlobalRegionManager(this, regionContainer);
     private FlagStateManager flagStateManager;
+    private final SimpleFlagRegistry flagRegistry = new SimpleFlagRegistry();
     private final Supervisor supervisor = new SimpleSupervisor();
     private ListeningExecutorService executorService;
     private ProfileService profileService;
@@ -104,6 +108,7 @@ public class WorldGuardPlugin extends JavaPlugin {
                 return plugin.hasPermission(player, perm);
             }
         };
+        flagRegistry.registerAll(DefaultFlag.getDefaultFlags());
     }
 
     /**
@@ -121,6 +126,7 @@ public class WorldGuardPlugin extends JavaPlugin {
     @SuppressWarnings("deprecation")
     public void onEnable() {
         configureLogger();
+        flagRegistry.setInitialized(true);
 
         getDataFolder().mkdirs(); // Need to create the plugins/WorldGuard folder
 
@@ -375,6 +381,15 @@ public class WorldGuardPlugin extends JavaPlugin {
      */
     public ProfileCache getProfileCache() {
         return profileCache;
+    }
+
+    /**
+     * Get the flag registry.
+     *
+     * @return the flag registry
+     */
+    public FlagRegistry getFlagRegistry() {
+        return flagRegistry;
     }
 
     /**

--- a/src/main/java/com/sk89q/worldguard/bukkit/commands/region/RegionCommands.java
+++ b/src/main/java/com/sk89q/worldguard/bukkit/commands/region/RegionCommands.java
@@ -49,6 +49,7 @@ import com.sk89q.worldguard.protection.flags.Flag;
 import com.sk89q.worldguard.protection.flags.InvalidFlagFormat;
 import com.sk89q.worldguard.protection.flags.RegionGroup;
 import com.sk89q.worldguard.protection.flags.RegionGroupFlag;
+import com.sk89q.worldguard.protection.flags.registry.FlagRegistry;
 import com.sk89q.worldguard.protection.managers.RegionManager;
 import com.sk89q.worldguard.protection.managers.RemovalStrategy;
 import com.sk89q.worldguard.protection.managers.migration.DriverMigration;
@@ -465,6 +466,7 @@ public final class RegionCommands extends RegionCommandsBase {
         String flagName = args.getString(1);
         String value = args.argsLength() >= 3 ? args.getJoinedStrings(2) : null;
         RegionGroup groupValue = null;
+        FlagRegistry flagRegistry = plugin.getFlagRegistry();
         RegionPermissionModel permModel = getPermissionModel(sender);
 
         if (args.hasFlag('e')) {
@@ -489,7 +491,7 @@ public final class RegionCommands extends RegionCommandsBase {
             throw new CommandPermissionsException();
         }
 
-        Flag<?> foundFlag = DefaultFlag.fuzzyMatchFlag(flagName);
+        Flag<?> foundFlag = DefaultFlag.fuzzyMatchFlag(flagRegistry, flagName);
 
         // We didn't find the flag, so let's print a list of flags that the user
         // can use, and do nothing afterwards
@@ -497,7 +499,7 @@ public final class RegionCommands extends RegionCommandsBase {
             StringBuilder list = new StringBuilder();
 
             // Need to build a list
-            for (Flag<?> flag : DefaultFlag.getFlags()) {
+            for (Flag<?> flag : flagRegistry) {
                 // Can the user set this flag?
                 if (!permModel.maySetFlag(existing, flag)) {
                     continue;
@@ -912,7 +914,7 @@ public final class RegionCommands extends RegionCommandsBase {
             throw new CommandException("The driver specified as 'to' does not seem to be supported in your version of WorldGuard.");
         }
 
-        DriverMigration migration = new DriverMigration(fromDriver, toDriver);
+        DriverMigration migration = new DriverMigration(fromDriver, toDriver, plugin.getFlagRegistry());
 
         LoggerToChatHandler handler = null;
         Logger minecraftLogger = null;
@@ -971,7 +973,7 @@ public final class RegionCommands extends RegionCommandsBase {
             ConfigurationManager config = plugin.getGlobalStateManager();
             RegionContainer container = plugin.getRegionContainer();
             RegionDriver driver = container.getDriver();
-            UUIDMigration migration = new UUIDMigration(driver, plugin.getProfileService());
+            UUIDMigration migration = new UUIDMigration(driver, plugin.getProfileService(), plugin.getFlagRegistry());
             migration.setKeepUnresolvedNames(config.keepUnresolvedNames);
             sender.sendMessage(ChatColor.YELLOW + "Now performing migration... this may take a while.");
             container.migrate(migration);

--- a/src/main/java/com/sk89q/worldguard/protection/flags/DefaultFlag.java
+++ b/src/main/java/com/sk89q/worldguard/protection/flags/DefaultFlag.java
@@ -19,9 +19,13 @@
 
 package com.sk89q.worldguard.protection.flags;
 
+import com.sk89q.worldguard.protection.flags.registry.FlagRegistry;
 import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
 import org.bukkit.entity.EntityType;
+
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * The flags that are used in WorldGuard.
@@ -148,18 +152,35 @@ public final class DefaultFlag {
     private DefaultFlag() {
     }
 
+    /**
+     * Get a list of default flags.
+     *
+     * @deprecated Use {@link FlagRegistry}
+     * @return An array of flags
+     */
+    @Deprecated
     public static Flag<?>[] getFlags() {
         return flagsList;
     }
 
     /**
+     * Get a list of default flags.
+     *
+     * @return An array of flags
+     */
+    public static List<Flag<?>> getDefaultFlags() {
+        return Arrays.asList(flagsList);
+    }
+
+    /**
      * Try to match the flag with the given ID using a fuzzy name match.
      *
+     * @param flagRegistry the flag registry
      * @param id the flag ID
      * @return a flag, or null
      */
-    public static Flag<?> fuzzyMatchFlag(String id) {
-        for (Flag<?> flag : DefaultFlag.getFlags()) {
+    public static Flag<?> fuzzyMatchFlag(FlagRegistry flagRegistry, String id) {
+        for (Flag<?> flag : flagRegistry) {
             if (flag.getName().replace("-", "").equalsIgnoreCase(id.replace("-", ""))) {
                 return flag;
             }
@@ -167,4 +188,5 @@ public final class DefaultFlag {
 
         return null;
     }
+
 }

--- a/src/main/java/com/sk89q/worldguard/protection/flags/Flags.java
+++ b/src/main/java/com/sk89q/worldguard/protection/flags/Flags.java
@@ -1,0 +1,64 @@
+/*
+ * WorldGuard, a suite of tools for Minecraft
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldGuard team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldguard.protection.flags;
+
+import com.google.common.collect.Maps;
+
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public final class Flags {
+
+    private static final Logger log = Logger.getLogger(Flags.class.getCanonicalName());
+
+    private Flags() {
+    }
+
+    /**
+     * Marshal a value of flag values into a map of raw values.
+     *
+     * @param values The unmarshalled flag values map
+     * @return The raw values map
+     */
+    public static Map<String, Object> marshal(Map<Flag<?>, Object> values) {
+        checkNotNull(values, "values");
+
+        Map<String, Object> rawValues = Maps.newHashMap();
+        for (Entry<Flag<?>, Object> entry : values.entrySet()) {
+            try {
+                rawValues.put(entry.getKey().getName(), marshal(entry.getKey(), entry.getValue()));
+            } catch (Exception e) {
+                log.log(Level.WARNING, "Failed to marshal flag value for " + entry.getKey() + "; value is " + entry.getValue(), e);
+            }
+        }
+
+        return rawValues;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> Object marshal(Flag<T> flag, Object value) {
+        return flag.marshal((T) value);
+    }
+
+}

--- a/src/main/java/com/sk89q/worldguard/protection/flags/registry/FlagConflictException.java
+++ b/src/main/java/com/sk89q/worldguard/protection/flags/registry/FlagConflictException.java
@@ -17,17 +17,12 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.sk89q.worldguard.protection;
+package com.sk89q.worldguard.protection.flags.registry;
 
-import com.sk89q.worldguard.protection.managers.index.HashMapIndex;
-import com.sk89q.worldguard.protection.managers.RegionManager;
-import com.sk89q.worldguard.protection.managers.storage.MemoryRegionDatabase;
+public class FlagConflictException extends RuntimeException {
 
-public class HashMapIndexRegionOverlapTest extends RegionOverlapTest {
-
-    @Override
-    protected RegionManager createRegionManager() throws Exception {
-        return new RegionManager(new MemoryRegionDatabase(), new HashMapIndex.Factory(), getFlagRegistry());
+    public FlagConflictException(String message) {
+        super(message);
     }
 
 }

--- a/src/main/java/com/sk89q/worldguard/protection/flags/registry/FlagRegistry.java
+++ b/src/main/java/com/sk89q/worldguard/protection/flags/registry/FlagRegistry.java
@@ -1,0 +1,85 @@
+/*
+ * WorldGuard, a suite of tools for Minecraft
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldGuard team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldguard.protection.flags.registry;
+
+import com.sk89q.worldguard.protection.flags.Flag;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Keeps track of registered flags.
+ */
+public interface FlagRegistry extends Iterable<Flag<?>> {
+
+    /**
+     * Register a new flag.
+     *
+     * <p>There may be an appropriate time to register flags. If flags are
+     * registered outside this time, then an exception may be thrown.</p>
+     *
+     * @param flag The flag
+     * @throws FlagConflictException Thrown when an existing flag exists with the same name
+     * @throws IllegalStateException If it is not the right time to register new flags
+     */
+    void register(Flag<?> flag) throws FlagConflictException;
+
+    /**
+     * Register a collection of flags.
+     *
+     * <p>There may be an appropriate time to register flags. If flags are
+     * registered outside this time, then an exception may be thrown.</p>
+     *
+     * <p>If there is a flag conflict, then an error will be logged but
+     * no exception will be thrown.</p>
+     *
+     * @param flags a collection of flags
+     * @throws IllegalStateException If it is not the right time to register new flags
+     */
+    void registerAll(Collection<Flag<?>> flags);
+
+    /**
+     * Get af flag by its name.
+     *
+     * @param name The name
+     * @return The flag, if it has been registered
+     */
+    @Nullable
+    Flag<?> get(String name);
+
+    /**
+     * Unmarshal a raw map of values into a map of flags with their
+     * unmarshalled values.
+     *
+     * @param rawValues The raw values map
+     * @param createUnknown Whether "just in time" flags should be created for unknown flags
+     * @return The unmarshalled flag values map
+     */
+    Map<Flag<?>, Object> unmarshal(Map<String, Object> rawValues, boolean createUnknown);
+
+    /**
+     * Get the number of registered flags.
+     *
+     * @return The number of registered flags
+     */
+    int size();
+
+}

--- a/src/main/java/com/sk89q/worldguard/protection/flags/registry/SimpleFlagRegistry.java
+++ b/src/main/java/com/sk89q/worldguard/protection/flags/registry/SimpleFlagRegistry.java
@@ -1,0 +1,148 @@
+/*
+ * WorldGuard, a suite of tools for Minecraft
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldGuard team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldguard.protection.flags.registry;
+
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Maps;
+import com.sk89q.worldguard.protection.flags.Flag;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class SimpleFlagRegistry implements FlagRegistry {
+
+    private static final Logger log = Logger.getLogger(SimpleFlagRegistry.class.getCanonicalName());
+
+    private final Object lock = new Object();
+    private final ConcurrentMap<String, Flag<?>> flags = Maps.newConcurrentMap();
+    private boolean initialized;
+
+    public boolean isInitialized() {
+        return initialized;
+    }
+
+    public void setInitialized(boolean initialized) {
+        this.initialized = initialized;
+    }
+
+    @Override
+    public void register(Flag<?> flag) throws FlagConflictException {
+        synchronized (lock) {
+            if (initialized) {
+                throw new IllegalStateException("New flags cannot be registered at this time");
+            }
+
+            forceRegister(flag);
+        }
+    }
+
+    @Override
+    public void registerAll(Collection<Flag<?>> flags) {
+        synchronized (lock) {
+            for (Flag<?> flag : flags) {
+                try {
+                    register(flag);
+                } catch (FlagConflictException e) {
+                    log.log(Level.WARNING, e.getMessage());
+                }
+            }
+        }
+    }
+
+    private Flag<?> forceRegister(Flag<?> flag) throws FlagConflictException {
+        checkNotNull(flag, "flag");
+        checkNotNull(flag.getName(), "flag.getName()");
+
+        synchronized (lock) {
+            String name = flag.getName().toLowerCase();
+            if (flags.containsKey(name)) {
+                throw new FlagConflictException("A flag already exists by the name " + name);
+            }
+
+            flags.put(name, flag);
+        }
+
+        return flag;
+    }
+
+    @Override
+    @Nullable
+    public Flag<?> get(String name) {
+        checkNotNull(name, "name");
+        return flags.get(name.toLowerCase());
+    }
+
+    private Flag<?> getOrCreate(String name) {
+        Flag<?> flag = get(name);
+
+        if (flag != null) {
+            return flag;
+        }
+
+        synchronized (lock) {
+            flag = get(name); // Load again because the previous load was not synchronized
+            return flag != null ? flag : forceRegister(new UnknownFlag(name));
+        }
+    }
+
+    @Override
+    public Map<Flag<?>, Object> unmarshal(Map<String, Object> rawValues, boolean createUnknown) {
+        checkNotNull(rawValues, "rawValues");
+
+        ConcurrentMap<Flag<?>, Object> values = Maps.newConcurrentMap();
+        for (Entry<String, Object> entry : rawValues.entrySet()) {
+            Flag<?> flag = createUnknown ? getOrCreate(entry.getKey()) : get(entry.getKey());
+
+            if (flag != null) {
+                try {
+                    Object unmarshalled = flag.unmarshal(entry.getValue());
+
+                    if (unmarshalled != null) {
+                        values.put(flag, unmarshalled);
+                    } else {
+                        log.warning("Failed to parse flag '" + flag.getName() + "' with value '" + entry.getValue() + "'");
+                    }
+                } catch (Exception e) {
+                    log.log(Level.WARNING, "Failed to unmarshal flag value for " + flag, e);
+                }
+            }
+        }
+
+        return values;
+    }
+
+    @Override
+    public int size() {
+        return flags.size();
+    }
+
+    @Override
+    public Iterator<Flag<?>> iterator() {
+        return Iterators.unmodifiableIterator(flags.values().iterator());
+    }
+}

--- a/src/main/java/com/sk89q/worldguard/protection/flags/registry/UnknownFlag.java
+++ b/src/main/java/com/sk89q/worldguard/protection/flags/registry/UnknownFlag.java
@@ -17,17 +17,34 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.sk89q.worldguard.protection;
+package com.sk89q.worldguard.protection.flags.registry;
 
-import com.sk89q.worldguard.protection.managers.index.HashMapIndex;
-import com.sk89q.worldguard.protection.managers.RegionManager;
-import com.sk89q.worldguard.protection.managers.storage.MemoryRegionDatabase;
+import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
+import com.sk89q.worldguard.protection.flags.Flag;
+import com.sk89q.worldguard.protection.flags.InvalidFlagFormat;
+import org.bukkit.command.CommandSender;
 
-public class HashMapIndexRegionOverlapTest extends RegionOverlapTest {
+import javax.annotation.Nullable;
+
+public class UnknownFlag extends Flag<Object> {
+
+    public UnknownFlag(String name) {
+        super(name);
+    }
 
     @Override
-    protected RegionManager createRegionManager() throws Exception {
-        return new RegionManager(new MemoryRegionDatabase(), new HashMapIndex.Factory(), getFlagRegistry());
+    public Object parseInput(WorldGuardPlugin plugin, CommandSender sender, String input) throws InvalidFlagFormat {
+        throw new InvalidFlagFormat("The plugin that registered this flag is not currently installed");
+    }
+
+    @Override
+    public Object unmarshal(@Nullable Object o) {
+        return o;
+    }
+
+    @Override
+    public Object marshal(Object o) {
+        return o;
     }
 
 }

--- a/src/main/java/com/sk89q/worldguard/protection/managers/RegionManager.java
+++ b/src/main/java/com/sk89q/worldguard/protection/managers/RegionManager.java
@@ -27,6 +27,7 @@ import com.sk89q.worldedit.Vector2D;
 import com.sk89q.worldguard.LocalPlayer;
 import com.sk89q.worldguard.protection.ApplicableRegionSet;
 import com.sk89q.worldguard.protection.RegionResultSet;
+import com.sk89q.worldguard.protection.flags.registry.FlagRegistry;
 import com.sk89q.worldguard.protection.managers.index.ConcurrentRegionIndex;
 import com.sk89q.worldguard.protection.managers.index.RegionIndex;
 import com.sk89q.worldguard.protection.managers.storage.DifferenceSaveException;
@@ -37,14 +38,7 @@ import com.sk89q.worldguard.protection.util.RegionCollectionConsumer;
 import com.sk89q.worldguard.util.Normal;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -57,6 +51,7 @@ public final class RegionManager {
 
     private final RegionDatabase store;
     private final Supplier<? extends ConcurrentRegionIndex> indexFactory;
+    private final FlagRegistry flagRegistry;
     private ConcurrentRegionIndex index;
 
     /**
@@ -64,14 +59,17 @@ public final class RegionManager {
      *
      * @param store the region store
      * @param indexFactory the factory for creating new instances of the index
+     * @param flagRegistry the flag registry
      */
-    public RegionManager(RegionDatabase store, Supplier<? extends ConcurrentRegionIndex> indexFactory) {
+    public RegionManager(RegionDatabase store, Supplier<? extends ConcurrentRegionIndex> indexFactory, FlagRegistry flagRegistry) {
         checkNotNull(store);
         checkNotNull(indexFactory);
+        checkNotNull(flagRegistry, "flagRegistry");
 
         this.store = store;
         this.indexFactory = indexFactory;
         this.index = indexFactory.get();
+        this.flagRegistry = flagRegistry;
     }
 
     /**
@@ -93,7 +91,7 @@ public final class RegionManager {
      * @throws StorageException thrown when loading fails
      */
     public void load() throws StorageException {
-        Set<ProtectedRegion> regions = store.loadAll();
+        Set<ProtectedRegion> regions = store.loadAll(flagRegistry);
         for (ProtectedRegion region : regions) {
             region.setDirty(false);
         }

--- a/src/main/java/com/sk89q/worldguard/protection/managers/migration/DriverMigration.java
+++ b/src/main/java/com/sk89q/worldguard/protection/managers/migration/DriverMigration.java
@@ -19,6 +19,8 @@
 
 package com.sk89q.worldguard.protection.managers.migration;
 
+import com.google.common.base.Preconditions;
+import com.sk89q.worldguard.protection.flags.registry.FlagRegistry;
 import com.sk89q.worldguard.protection.managers.storage.RegionDatabase;
 import com.sk89q.worldguard.protection.managers.storage.RegionDriver;
 import com.sk89q.worldguard.protection.managers.storage.StorageException;
@@ -36,17 +38,21 @@ public class DriverMigration extends AbstractMigration {
 
     private static final Logger log = Logger.getLogger(DriverMigration.class.getCanonicalName());
     private final RegionDriver target;
+    private final FlagRegistry flagRegistry;
 
     /**
      * Create a new instance.
      *
      * @param driver the source storage driver
      * @param target the target storage driver
+     * @param flagRegistry the flag registry
      */
-    public DriverMigration(RegionDriver driver, RegionDriver target) {
+    public DriverMigration(RegionDriver driver, RegionDriver target, FlagRegistry flagRegistry) {
         super(driver);
         checkNotNull(target);
+        Preconditions.checkNotNull(flagRegistry, "flagRegistry");
         this.target = target;
+        this.flagRegistry = flagRegistry;
     }
 
     @Override
@@ -56,7 +62,7 @@ public class DriverMigration extends AbstractMigration {
         log.info("Loading the regions for '" + store.getName() + "' with the old driver...");
 
         try {
-            regions = store.loadAll();
+            regions = store.loadAll(flagRegistry);
         } catch (StorageException e) {
             throw new MigrationException("Failed to load region data for the world '" + store.getName() + "'", e);
         }

--- a/src/main/java/com/sk89q/worldguard/protection/managers/migration/UUIDMigration.java
+++ b/src/main/java/com/sk89q/worldguard/protection/managers/migration/UUIDMigration.java
@@ -24,18 +24,14 @@ import com.sk89q.squirrelid.Profile;
 import com.sk89q.squirrelid.resolver.ProfileService;
 import com.sk89q.worldguard.domains.DefaultDomain;
 import com.sk89q.worldguard.domains.PlayerDomain;
+import com.sk89q.worldguard.protection.flags.registry.FlagRegistry;
 import com.sk89q.worldguard.protection.managers.storage.RegionDatabase;
 import com.sk89q.worldguard.protection.managers.storage.RegionDriver;
 import com.sk89q.worldguard.protection.managers.storage.StorageException;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 
 import java.io.IOException;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.Timer;
-import java.util.TimerTask;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Level;
@@ -53,6 +49,7 @@ public class UUIDMigration extends AbstractMigration {
 
     private final Timer timer = new Timer();
     private final ProfileService profileService;
+    private final FlagRegistry flagRegistry;
     private final ConcurrentMap<String, UUID> resolvedNames = new ConcurrentHashMap<String, UUID>();
     private final Set<String> unresolvedNames = new HashSet<String>();
     private boolean keepUnresolvedNames = true;
@@ -62,11 +59,14 @@ public class UUIDMigration extends AbstractMigration {
      *
      * @param driver the storage driver
      * @param profileService the profile service
+     * @param flagRegistry the flag registry
      */
-    public UUIDMigration(RegionDriver driver, ProfileService profileService) {
+    public UUIDMigration(RegionDriver driver, ProfileService profileService, FlagRegistry flagRegistry) {
         super(driver);
         checkNotNull(profileService);
+        checkNotNull(flagRegistry, "flagRegistry");
         this.profileService = profileService;
+        this.flagRegistry = flagRegistry;
     }
 
     @Override
@@ -76,7 +76,7 @@ public class UUIDMigration extends AbstractMigration {
         Set<ProtectedRegion> regions;
 
         try {
-            regions = store.loadAll();
+            regions = store.loadAll(flagRegistry);
         } catch (StorageException e) {
             throw new MigrationException("Failed to load region data for the world '" + store.getName() + "'", e);
         }

--- a/src/main/java/com/sk89q/worldguard/protection/managers/storage/MemoryRegionDatabase.java
+++ b/src/main/java/com/sk89q/worldguard/protection/managers/storage/MemoryRegionDatabase.java
@@ -19,6 +19,7 @@
 
 package com.sk89q.worldguard.protection.managers.storage;
 
+import com.sk89q.worldguard.protection.flags.registry.FlagRegistry;
 import com.sk89q.worldguard.protection.managers.RegionDifference;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 
@@ -42,7 +43,7 @@ public class MemoryRegionDatabase implements RegionDatabase {
     }
 
     @Override
-    public Set<ProtectedRegion> loadAll() {
+    public Set<ProtectedRegion> loadAll(FlagRegistry flagRegistry) {
         return regions;
     }
 

--- a/src/main/java/com/sk89q/worldguard/protection/managers/storage/RegionDatabase.java
+++ b/src/main/java/com/sk89q/worldguard/protection/managers/storage/RegionDatabase.java
@@ -19,6 +19,7 @@
 
 package com.sk89q.worldguard.protection.managers.storage;
 
+import com.sk89q.worldguard.protection.flags.registry.FlagRegistry;
 import com.sk89q.worldguard.protection.managers.RegionDifference;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 
@@ -53,10 +54,11 @@ public interface RegionDatabase {
      * {@code get()} and {@code put()} calls in order to maximize performance.
      * </p>
      *
+     * @param flags a flag registry
      * @return a set of loaded regions
      * @throws StorageException thrown on read error
      */
-    Set<ProtectedRegion> loadAll() throws StorageException;
+    Set<ProtectedRegion> loadAll(FlagRegistry flags) throws StorageException;
 
     /**
      * Replace all the data in the store with the given collection of regions.

--- a/src/main/java/com/sk89q/worldguard/protection/managers/storage/RegionDatabaseUtils.java
+++ b/src/main/java/com/sk89q/worldguard/protection/managers/storage/RegionDatabaseUtils.java
@@ -19,7 +19,6 @@
 
 package com.sk89q.worldguard.protection.managers.storage;
 
-import com.sk89q.worldguard.protection.flags.DefaultFlag;
 import com.sk89q.worldguard.protection.flags.Flag;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion.CircularInheritanceException;
@@ -41,62 +40,6 @@ public final class RegionDatabaseUtils {
     private static final Logger log = Logger.getLogger(RegionDatabaseUtils.class.getCanonicalName());
 
     private RegionDatabaseUtils() {
-    }
-
-    /**
-     * Try setting the given map of flags onto the region.
-     *
-     * @param region the region
-     * @param flagData the map of flag data
-     */
-    public static void trySetFlagMap(ProtectedRegion region, Map<String, Object> flagData) {
-        checkNotNull(region);
-        checkNotNull(flagData);
-
-        for (Flag<?> flag : DefaultFlag.getFlags()) {
-            if (flag == null) {
-                // Some plugins that add custom flags to WorldGuard are doing
-                // something very wrong -- see WORLDGUARD-3094
-                continue;
-            }
-
-            Object o = flagData.get(flag.getName());
-            if (o != null) {
-                RegionDatabaseUtils.trySetFlag(region, flag, o);
-            }
-
-            // Set group
-            if (flag.getRegionGroupFlag() != null) {
-                Object o2 = flagData.get(flag.getRegionGroupFlag().getName());
-                if (o2 != null) {
-                    RegionDatabaseUtils.trySetFlag(region, flag.getRegionGroupFlag(), o2);
-                }
-            }
-        }
-    }
-
-    /**
-     * Try to set a flag on the region.
-     *
-     * @param region the region
-     * @param flag the flag
-     * @param value the value of the flag, which may be {@code null}
-     * @param <T> the flag's type
-     * @return true if the set succeeded
-     */
-    public static <T> boolean trySetFlag(ProtectedRegion region, Flag<T> flag, @Nullable Object value) {
-        checkNotNull(region);
-        checkNotNull(flag);
-
-        T val = flag.unmarshal(value);
-
-        if (val != null) {
-            region.setFlag(flag, val);
-            return true;
-        } else {
-            log.warning("Failed to parse flag '" + flag.getName() + "' with value '" + value + "'");
-            return false;
-        }
     }
 
     /**

--- a/src/main/java/com/sk89q/worldguard/protection/managers/storage/sql/SQLRegionDatabase.java
+++ b/src/main/java/com/sk89q/worldguard/protection/managers/storage/sql/SQLRegionDatabase.java
@@ -19,6 +19,7 @@
 
 package com.sk89q.worldguard.protection.managers.storage.sql;
 
+import com.sk89q.worldguard.protection.flags.registry.FlagRegistry;
 import com.sk89q.worldguard.protection.managers.RegionDifference;
 import com.sk89q.worldguard.protection.managers.storage.DifferenceSaveException;
 import com.sk89q.worldguard.protection.managers.storage.RegionDatabase;
@@ -198,7 +199,7 @@ class SQLRegionDatabase implements RegionDatabase {
     }
 
     @Override
-    public Set<ProtectedRegion> loadAll() throws StorageException {
+    public Set<ProtectedRegion> loadAll(FlagRegistry flagRegistry) throws StorageException {
         initialize();
 
         Closer closer = Closer.create();
@@ -206,7 +207,7 @@ class SQLRegionDatabase implements RegionDatabase {
 
         try {
             try {
-                loader = new DataLoader(this, closer.register(getConnection()));
+                loader = new DataLoader(this, closer.register(getConnection()), flagRegistry);
             } catch (SQLException e) {
                 throw new StorageException("Failed to get a connection to the database", e);
             }

--- a/src/test/java/com/sk89q/worldguard/protection/HashMapIndexPriorityTest.java
+++ b/src/test/java/com/sk89q/worldguard/protection/HashMapIndexPriorityTest.java
@@ -27,7 +27,7 @@ public class HashMapIndexPriorityTest extends RegionPriorityTest {
 
     @Override
     protected RegionManager createRegionManager() throws Exception {
-        return new RegionManager(new MemoryRegionDatabase(), new HashMapIndex.Factory());
+        return new RegionManager(new MemoryRegionDatabase(), new HashMapIndex.Factory(), getFlagRegistry());
     }
 
 }

--- a/src/test/java/com/sk89q/worldguard/protection/HashMapIndexTest.java
+++ b/src/test/java/com/sk89q/worldguard/protection/HashMapIndexTest.java
@@ -19,15 +19,15 @@
 
 package com.sk89q.worldguard.protection;
 
-import com.sk89q.worldguard.protection.managers.index.HashMapIndex;
 import com.sk89q.worldguard.protection.managers.RegionManager;
+import com.sk89q.worldguard.protection.managers.index.HashMapIndex;
 import com.sk89q.worldguard.protection.managers.storage.MemoryRegionDatabase;
 
 public class HashMapIndexTest extends RegionOverlapTest {
 
     @Override
     protected RegionManager createRegionManager() throws Exception {
-        return new RegionManager(new MemoryRegionDatabase(), new HashMapIndex.Factory());
+        return new RegionManager(new MemoryRegionDatabase(), new HashMapIndex.Factory(), getFlagRegistry());
     }
 
 }

--- a/src/test/java/com/sk89q/worldguard/protection/PriorityRTreeIndexTest.java
+++ b/src/test/java/com/sk89q/worldguard/protection/PriorityRTreeIndexTest.java
@@ -27,7 +27,7 @@ public class PriorityRTreeIndexTest extends RegionOverlapTest {
 
     @Override
     protected RegionManager createRegionManager() throws Exception {
-        return new RegionManager(new MemoryRegionDatabase(), new PriorityRTreeIndex.Factory());
+        return new RegionManager(new MemoryRegionDatabase(), new PriorityRTreeIndex.Factory(), getFlagRegistry());
     }
 
 }

--- a/src/test/java/com/sk89q/worldguard/protection/PriorityRTreeRegionEntryExitTest.java
+++ b/src/test/java/com/sk89q/worldguard/protection/PriorityRTreeRegionEntryExitTest.java
@@ -27,7 +27,7 @@ public class PriorityRTreeRegionEntryExitTest extends RegionEntryExitTest {
 
     @Override
     protected RegionManager createRegionManager() throws Exception {
-        return new RegionManager(new MemoryRegionDatabase(), new PriorityRTreeIndex.Factory());
+        return new RegionManager(new MemoryRegionDatabase(), new PriorityRTreeIndex.Factory(), getFlagRegistry());
     }
 
 }

--- a/src/test/java/com/sk89q/worldguard/protection/PriorityRTreeRegionOverlapTest.java
+++ b/src/test/java/com/sk89q/worldguard/protection/PriorityRTreeRegionOverlapTest.java
@@ -27,7 +27,7 @@ public class PriorityRTreeRegionOverlapTest extends RegionOverlapTest {
 
     @Override
     protected RegionManager createRegionManager() throws Exception {
-        return new RegionManager(new MemoryRegionDatabase(), new PriorityRTreeIndex.Factory());
+        return new RegionManager(new MemoryRegionDatabase(), new PriorityRTreeIndex.Factory(), getFlagRegistry());
     }
 
 }

--- a/src/test/java/com/sk89q/worldguard/protection/PriorityRTreeRegionPriorityTest.java
+++ b/src/test/java/com/sk89q/worldguard/protection/PriorityRTreeRegionPriorityTest.java
@@ -27,7 +27,7 @@ public class PriorityRTreeRegionPriorityTest extends RegionPriorityTest {
 
     @Override
     protected RegionManager createRegionManager() throws Exception {
-        return new RegionManager(new MemoryRegionDatabase(), new PriorityRTreeIndex.Factory());
+        return new RegionManager(new MemoryRegionDatabase(), new PriorityRTreeIndex.Factory(), getFlagRegistry());
     }
 
 }

--- a/src/test/java/com/sk89q/worldguard/protection/RegionEntryExitTest.java
+++ b/src/test/java/com/sk89q/worldguard/protection/RegionEntryExitTest.java
@@ -26,6 +26,8 @@ import com.sk89q.worldguard.domains.DefaultDomain;
 import com.sk89q.worldguard.protection.flags.DefaultFlag;
 import com.sk89q.worldguard.protection.flags.RegionGroup;
 import com.sk89q.worldguard.protection.flags.StateFlag;
+import com.sk89q.worldguard.protection.flags.registry.FlagRegistry;
+import com.sk89q.worldguard.protection.flags.registry.SimpleFlagRegistry;
 import com.sk89q.worldguard.protection.managers.RegionManager;
 import com.sk89q.worldguard.protection.regions.GlobalProtectedRegion;
 import com.sk89q.worldguard.protection.regions.ProtectedCuboidRegion;
@@ -52,6 +54,12 @@ public abstract class RegionEntryExitTest {
     ProtectedRegion exitRegion;
     TestPlayer vipPlayer;
     TestPlayer builderPlayer;
+
+    protected FlagRegistry getFlagRegistry() {
+        FlagRegistry registry = new SimpleFlagRegistry();
+        registry.registerAll(DefaultFlag.getDefaultFlags());
+        return registry;
+    }
 
     protected abstract RegionManager createRegionManager() throws Exception;
 

--- a/src/test/java/com/sk89q/worldguard/protection/RegionOverlapTest.java
+++ b/src/test/java/com/sk89q/worldguard/protection/RegionOverlapTest.java
@@ -19,15 +19,6 @@
 
 package com.sk89q.worldguard.protection;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import java.util.ArrayList;
-import java.util.HashSet;
-
-import org.junit.Before;
-import org.junit.Test;
-
 import com.sk89q.worldedit.BlockVector;
 import com.sk89q.worldedit.BlockVector2D;
 import com.sk89q.worldedit.Vector;
@@ -35,11 +26,21 @@ import com.sk89q.worldguard.TestPlayer;
 import com.sk89q.worldguard.domains.DefaultDomain;
 import com.sk89q.worldguard.protection.flags.DefaultFlag;
 import com.sk89q.worldguard.protection.flags.StateFlag;
+import com.sk89q.worldguard.protection.flags.registry.FlagRegistry;
+import com.sk89q.worldguard.protection.flags.registry.SimpleFlagRegistry;
 import com.sk89q.worldguard.protection.managers.RegionManager;
 import com.sk89q.worldguard.protection.regions.GlobalProtectedRegion;
 import com.sk89q.worldguard.protection.regions.ProtectedCuboidRegion;
 import com.sk89q.worldguard.protection.regions.ProtectedPolygonalRegion;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public abstract class RegionOverlapTest {
     static String COURTYARD_ID = "courtyard";
@@ -58,6 +59,12 @@ public abstract class RegionOverlapTest {
     ProtectedRegion fountain;
     TestPlayer player1;
     TestPlayer player2;
+
+    protected FlagRegistry getFlagRegistry() {
+        FlagRegistry registry = new SimpleFlagRegistry();
+        registry.registerAll(DefaultFlag.getDefaultFlags());
+        return registry;
+    }
     
     protected abstract RegionManager createRegionManager() throws Exception;
 

--- a/src/test/java/com/sk89q/worldguard/protection/RegionPriorityTest.java
+++ b/src/test/java/com/sk89q/worldguard/protection/RegionPriorityTest.java
@@ -26,6 +26,8 @@ import com.sk89q.worldguard.TestPlayer;
 import com.sk89q.worldguard.domains.DefaultDomain;
 import com.sk89q.worldguard.protection.flags.DefaultFlag;
 import com.sk89q.worldguard.protection.flags.StateFlag;
+import com.sk89q.worldguard.protection.flags.registry.FlagRegistry;
+import com.sk89q.worldguard.protection.flags.registry.SimpleFlagRegistry;
 import com.sk89q.worldguard.protection.managers.RegionManager;
 import com.sk89q.worldguard.protection.regions.GlobalProtectedRegion;
 import com.sk89q.worldguard.protection.regions.ProtectedCuboidRegion;
@@ -55,6 +57,12 @@ public abstract class RegionPriorityTest {
     ProtectedRegion fountain;
     TestPlayer player1;
     TestPlayer player2;
+
+    protected FlagRegistry getFlagRegistry() {
+        FlagRegistry registry = new SimpleFlagRegistry();
+        registry.registerAll(DefaultFlag.getDefaultFlags());
+        return registry;
+    }
     
     protected abstract RegionManager createRegionManager() throws Exception;
 


### PR DESCRIPTION
Performence Problem

When Player teleports,
the TPS decrease about 2~ 6 By WorldGuarD.


11:57:27 INFO]: Tick Length: 386 milliseconds
11:57:27 INFO]: TPS Reduction: 6.7 (20.0 --> 13.3)
11:57:27 INFO]: Stack Tree: (36 samples)
11:57:27 INFO]: 50.00% com.sk89q.worldguard.bukkit.listener.WorldGuardPlayerListener.onPlayerTeleport(WorldGuardPlayerL
stener.java:373)
11:57:27 INFO]: 50.00% com.sk89q.worldguard.session.Session.testMoveTo(Session.java:177)
11:57:27 INFO]: 50.00% com.sk89q.worldguard.session.Session.testMoveTo(Session.java:217)
11:57:27 INFO]:  5.56% net.goldtreeservers.worldguardextraflags.wg.handlers.GlideFlagHandler.onCrossBoundary(GlideFlagH
ndler.java:47)
11:57:27 INFO]:  5.56% net.goldtreeservers.worldguardextraflags.wg.WorldGuardUtils.queryState(WorldGuardUtils.java:43)
11:57:27 INFO]:   2.78% net.goldtreeservers.worldguardextraflags.wg.WorldGuardUtils.createFlagValueCalculator(WorldGuar
Utils.java:72) (children hidden)
11:57:27 INFO]:   2.78% net.goldtreeservers.worldguardextraflags.wg.WorldGuardUtils.createFlagValueCalculator(WorldGuar
Utils.java:61) (children hidden)
11:57:27 INFO]:  5.56% net.goldtreeservers.worldguardextraflags.wg.handlers.FlyFlagHandler.onCrossBoundary(FlyFlagHandl
r.java:49)
11:57:27 INFO]:  5.56% net.goldtreeservers.worldguardextraflags.wg.WorldGuardUtils.queryState(WorldGuardUtils.java:43)
11:57:27 INFO]:   2.78% net.goldtreeservers.worldguardextraflags.wg.WorldGuardUtils.createFlagValueCalculator(WorldGuar
Utils.java:72) (children hidden)
11:57:27 INFO]:   2.78% net.goldtreeservers.worldguardextraflags.wg.WorldGuardUtils.createFlagValueCalculator(WorldGuar
Utils.java:61) (children hidden)
11:57:27 INFO]:  5.56% net.goldtreeservers.worldguardextraflags.wg.handlers.BlockedEffectsFlagHandler.onCrossBoundary(B
ockedEffectsFlagHandler.java:55)
11:57:27 INFO]:  5.56% net.goldtreeservers.worldguardextraflags.wg.handlers.BlockedEffectsFlagHandler.check(BlockedEffe
tsFlagHandler.java:68)
11:57:27 INFO]:  5.56% net.goldtreeservers.worldguardextraflags.wg.WorldGuardUtils.queryValue(WorldGuardUtils.java:48)
11:57:27 INFO]:   2.78% net.goldtreeservers.worldguardextraflags.wg.WorldGuardUtils.createFlagValueCalculator(WorldGuar
Utils.java:72) (children hidden)
11:57:27 INFO]:   2.78% net.goldtreeservers.worldguardextraflags.wg.WorldGuardUtils.createFlagValueCalculator(WorldGuar
Utils.java:61) (children hidden)
11:57:27 INFO]:  5.56% net.goldtreeservers.worldguardextraflags.wg.handlers.ConsoleCommandOnExitFlagHandler.onCrossBoun
ary(ConsoleCommandOnExitFlagHandler.java:50)
11:57:27 INFO]:  5.56% net.goldtreeservers.worldguardextraflags.wg.WorldGuardUtils.queryAllValues(WorldGuardUtils.java:
3)
11:57:27 INFO]:   2.78% net.goldtreeservers.worldguardextraflags.wg.WorldGuardUtils.createFlagValueCalculator(WorldGuar
Utils.java:72) (children hidden)
11:57:27 INFO]:   2.78% net.goldtreeservers.worldguardextraflags.wg.WorldGuardUtils.createFlagValueCalculator(WorldGuar
Utils.java:61) (children hidden)
11:57:27 INFO]:  5.56% net.goldtreeservers.worldguardextraflags.wg.handlers.ConsoleCommandOnEntryFlagHandler.onCrossBou
dary(ConsoleCommandOnEntryFlagHandler.java:44)
11:57:27 INFO]:  5.56% net.goldtreeservers.worldguardextraflags.wg.WorldGuardUtils.queryAllValues(WorldGuardUtils.java:
3)
11:57:27 INFO]:   2.78% net.goldtreeservers.worldguardextraflags.wg.WorldGuardUtils.createFlagValueCalculator(WorldGuar
Utils.java:72) (children hidden)
11:57:27 INFO]:   2.78% net.goldtreeservers.worldguardextraflags.wg.WorldGuardUtils.createFlagValueCalculator(WorldGuar
Utils.java:61) (children hidden)
11:57:27 INFO]:  2.78% net.goldtreeservers.worldguardextraflags.wg.handlers.PlaySoundsFlagHandler.onCrossBoundary(PlayS
undsFlagHandler.java:55) (children hidden)
11:57:27 INFO]:  2.78% net.goldtreeservers.worldguardextraflags.wg.handlers.GiveEffectsFlagHandler.onCrossBoundary(Give
ffectsFlagHandler.java:61) (children hidden)
11:57:27 INFO]:  2.78% net.goldtreeservers.worldguardextraflags.wg.handlers.GodmodeFlagHandler.onCrossBoundary(GodmodeF
agHandler.java:54) (children hidden)
11:57:27 INFO]:  2.78% net.goldtreeservers.worldguardextraflags.wg.handlers.WalkSpeedFlagHandler.onCrossBoundary(WalkSp
edFlagHandler.java:46) (children hidden)
11:57:27 INFO]:  2.78% net.goldtreeservers.worldguardextraflags.wg.handlers.CommandOnExitFlagHandler.onCrossBoundary(Co
mandOnExitFlagHandler.java:50) (children hidden)
11:57:27 INFO]:  2.78% net.goldtreeservers.worldguardextraflags.wg.handlers.CommandOnEntryFlagHandler.onCrossBoundary(C
mmandOnEntryFlagHandler.java:44) (children hidden)
11:57:27 INFO]:  2.78% net.goldtreeservers.worldguardextraflags.wg.handlers.TeleportOnExitFlagHandler.onCrossBoundary(T
leportOnExitFlagHandler.java:43) (children hidden)
11:57:27 INFO]:  2.78% net.goldtreeservers.worldguardextraflags.wg.handlers.TeleportOnEntryFlagHandler.onCrossBoundary(
eleportOnEntryFlagHandler.java:43) (children hidden)
11:57:27 INFO]: 22.22% org.bukkit.command.PluginCommand.execute(PluginCommand.java:44)
11:57:27 INFO]: 22.22% com.earth2me.essentials.Essentials.onCommand(Essentials.java:430)
11:57:27 INFO]:  13.89% com.earth2me.essentials.Essentials.onCommandEssentials(Essentials.java:517)
11:57:27 INFO]:  13.89% com.earth2me.essentials.commands.EssentialsCommand.run(EssentialsCommand.java:157)
11:57:27 INFO]:   5.56% com.earth2me.essentials.commands.EssentialsCommand.run(EssentialsCommand.java:162)
11:57:27 INFO]:    2.78% com.earth2me.essentials.commands.Commandgive.run(Commandgive.java:71) (children hidden)
11:57:27 INFO]:    2.78% com.earth2me.essentials.commands.Commandgive.run(Commandgive.java:36) (children hidden)
11:57:27 INFO]:   2.78% com.earth2me.essentials.commands.Commandtp.run(Commandtp.java:61) (children hidden)
11:57:27 INFO]:   2.78% com.earth2me.essentials.commands.Commandtp.run(Commandtp.java:55) (children hidden)
11:57:27 INFO]:   2.78% com.earth2me.essentials.commands.Commandtp.run(Commandtp.java:58) (children hidden)
11:57:27 INFO]:  5.56% com.earth2me.essentials.Essentials.onCommandEssentials(Essentials.java:470)
11:57:27 INFO]:  5.56% com.earth2me.essentials.User.isAuthorized(User.java:96)
11:57:27 INFO]:  5.56% com.earth2me.essentials.User.isAuthorizedCheck(User.java:110)
11:57:27 INFO]:  5.56% com.earth2me.essentials.perm.PermissionsHandler.hasPermission(PermissionsHandler.java:62)
11:57:27 INFO]:  5.56% com.earth2me.essentials.perm.impl.SuperpermsHandler.hasPermission(SuperpermsHandler.java:38)
11:57:27 INFO]:  5.56% org.bukkit.craftbukkit.v1_12_R1.entity.CraftHumanEntity.isPermissionSet(CraftHumanEntity.java:10
)
11:57:27 INFO]:  5.56% ru.tehkode.permissions.bukkit.regexperms.PermissiblePEX.isPermissionSet(PermissiblePEX.java:201)

11:57:27 INFO]:  5.56% ru.tehkode.permissions.bukkit.regexperms.PermissiblePEX.permissionValue(PermissiblePEX.java:241)

11:57:27 INFO]:  5.56% ru.tehkode.permissions.bukkit.regexperms.PermissiblePEX.checkSingle(PermissiblePEX.java:213)
11:57:27 INFO]:  5.56% ru.tehkode.permissions.RegExpMatcher.isMatches(RegExpMatcher.java:27)
11:57:27 INFO]:  5.56% com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:5147)
11:57:27 INFO]:  5.56% com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:4158)
11:57:27 INFO]:  5.56% com.google.common.cache.LocalCache.get(LocalCache.java:4154)
11:57:27 INFO]:  5.56% com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2211)
11:57:27 INFO]:  5.56% com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2298)
11:57:27 INFO]:   2.78% com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2424) (children hidden)
11:57:27 INFO]:   2.78% com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2425) (children hidden)
11:57:27 INFO]:  2.78% com.earth2me.essentials.Essentials.onCommandEssentials(Essentials.java:497) (children hidden)
11:57:27 INFO]: 11.11% java.lang.Thread.run(Unknown Source)
11:57:27 INFO]: 11.11% net.minecraft.server.v1_12_R1.MinecraftServer.run(MinecraftServer.java:577)
11:57:27 INFO]: 11.11% net.minecraft.server.v1_12_R1.MinecraftServer.C(MinecraftServer.java:679)
11:57:27 INFO]: 11.11% net.minecraft.server.v1_12_R1.DedicatedServer.D(DedicatedServer.java:406)
11:57:27 INFO]:  8.33% net.minecraft.server.v1_12_R1.MinecraftServer.D(MinecraftServer.java:801)
11:57:27 INFO]:  8.33% net.minecraft.server.v1_12_R1.WorldServer.doTick(WorldServer.java:316)
11:57:27 INFO]:   5.56% net.minecraft.server.v1_12_R1.WorldServer.j(WorldServer.java:552)
11:57:27 INFO]:   5.56% net.minecraft.server.v1_12_R1.Block.a(Block.java:304)
11:57:27 INFO]:    2.78% net.minecraft.server.v1_12_R1.BlockGrass.b(BlockGrass.java:58) (children hidden)
11:57:27 INFO]:    2.78% net.minecraft.server.v1_12_R1.BlockGrass.b(BlockGrass.java:32) (children hidden)
11:57:27 INFO]:   2.78% net.minecraft.server.v1_12_R1.WorldServer.j(WorldServer.java:547) (children hidden)
11:57:27 INFO]:  2.78% net.minecraft.server.v1_12_R1.MinecraftServer.D(MinecraftServer.java:817) (children hidden)
11:57:27 INFO]: 8.33% com.wizardscraft.scripting.BukkitThreadRunner.run(BukkitThreadRunner.java:90)
11:57:27 INFO]: 8.33% org.bukkit.craftbukkit.v1_12_R1.entity.CraftPlayer.setOp(CraftPlayer.java:111)
11:57:27 INFO]: 8.33% net.minecraft.server.v1_12_R1.DedicatedPlayerList.addOp(SourceFile:46)
11:57:27 INFO]:  5.56% net.minecraft.server.v1_12_R1.PlayerList.addOp(PlayerList.java:1145)
11:57:27 INFO]:  5.56% org.bukkit.craftbukkit.v1_12_R1.entity.CraftHumanEntity.recalculatePermissions(CraftHumanEntity.
ava:140)
11:57:27 INFO]:   2.78% ru.tehkode.permissions.bukkit.regexperms.PermissiblePEX.recalculatePermissions(PermissiblePEX.j
va:181) (children hidden)

va:183) (children hidden)
11:57:27 INFO]:  2.78% net.minecraft.server.v1_12_R1.PlayerList.addOp(PlayerList.java:1141) (children hidden)
11:57:27 INFO]: 2.78% fr.neatmonster.nocheatplus.checks.moving.MovingListener.onPlayerMove(MovingListener.java:479) (ch
ldren hidden)
11:57:27 INFO]: 2.78% me.konsolas.aac.n.a(n.java:124) (children hidden)
11:57:27 INFO]: 2.78% com.wizardscraft.scripting.BukkitThreadRunner.run(BukkitThreadRunner.java:96) (children hidden)

12:17:42 INFO]: 68.00% com.sk89q.worldguard.bukkit.listener.WorldGuardPlayerListener.onPlayerTeleport(WorldGuardPlayerL
stener.java:373)
12:17:42 INFO]: 68.00% com.sk89q.worldguard.session.Session.testMoveTo(Session.java:177)
12:17:42 INFO]: 68.00% com.sk89q.worldguard.session.Session.testMoveTo(Session.java:217)
12:17:42 INFO]:  8.00% net.goldtreeservers.worldguardextraflags.wg.handlers.PlaySoundsFlagHandler.onCrossBoundary(PlayS
undsFlagHandler.java:55)
12:17:42 INFO]:  8.00% net.goldtreeservers.worldguardextraflags.wg.handlers.PlaySoundsFlagHandler.check(PlaySoundsFlagH
ndler.java:67)
12:17:42 INFO]:  8.00% net.goldtreeservers.worldguardextraflags.wg.WorldGuardUtils.queryValue(WorldGuardUtils.java:48)

"12:17:42 INFO]: 68.00% com.sk89q.worldguard.bukkit.listener.WorldGuardPlayerListener.onPlayerTeleport(WorldGuardPlayerL
stener.java:373)
12:17:42 INFO]: 68.00% com.sk89q.worldguard.session.Session.testMoveTo(Session.java:177)
12:17:42 INFO]: 68.00% com.sk89q.worldguard.session.Session.testMoveTo(Session.java:217)
12:17:42 INFO]:  8.00% net.goldtreeservers.worldguardextraflags.wg.handlers.PlaySoundsFlagHandler.onCrossBoundary(PlayS
undsFlagHandler.java:55)
12:17:42 INFO]:  8.00% net.goldtreeservers.worldguardextraflags.wg.handlers.PlaySoundsFlagHandler.check(PlaySoundsFlagH
ndler.java:67)
12:17:42 INFO]:  8.00% net.goldtreeservers.worldguardextraflags.wg.WorldGuardUtils.queryValue(WorldGuardUtils.java:48)