### PR TITLE
Prevent database error

### DIFF
--- a/worldguard-legacy/src/main/resources/migrations/region/mysql/V1__Initial.sql
+++ b/worldguard-legacy/src/main/resources/migrations/region/mysql/V1__Initial.sql
@@ -87,7 +87,7 @@ CREATE  TABLE IF NOT EXISTS `${tablePrefix}region_flag` (
   `region_id` VARCHAR(128) CHARACTER SET 'utf8' COLLATE 'utf8_bin' NOT NULL ,
   `world_id` INT(10) UNSIGNED NOT NULL ,
   `flag` VARCHAR(45) CHARACTER SET 'utf8' COLLATE 'utf8_bin' NOT NULL ,
-  `value` VARCHAR(256) CHARACTER SET 'utf8' COLLATE 'utf8_bin' NOT NULL ,
+  `value` VARCHAR(512) CHARACTER SET 'utf8' COLLATE 'utf8_bin' NOT NULL ,
   PRIMARY KEY (`id`) ,
   INDEX `fk_flags_region` (`region_id` ASC, `world_id` ASC) ,
   CONSTRAINT `fk_${tablePrefix}flags_region`


### PR DESCRIPTION
Set max chars from field "value" higher to prevent errors with new 1.13 entitytypes in database.

Example entry in field "value" in table "worldnameXYZ_regions_flag" for flag denyspawn with some 1.13 EntityTypes: 

```
['minecraft:polar_bear', 'minecraft:skeleton', 'minecraft:giant', 'minecraft:witch',
  'minecraft:zombie_pigman', 'minecraft:wither_skull', 'minecraft:husk', 'minecraft:ender_dragon',
  'minecraft:cave_spider', 'minecraft:guardian', 'minecraft:silverfish', 'minecraft:stray',
  'minecraft:vindicator', 'minecraft:endermite', 'minecraft:magma_cube', 'minecraft:spider',
  'minecraft:vex', 'minecraft:zombie', 'minecraft:creeper', 'minecraft:wither', 'minecraft:zombie_villager',
  'minecraft:evoker']
```

Its to big for 256 chars.

Error

```
[19:17:28 WARN]: [WorldGuard] Failed to save the region data for 'akania' during a periodical save
com.sk89q.worldguard.protection.managers.storage.StorageException: Failed to save the region data to the database
        at com.sk89q.worldguard.protection.managers.storage.sql.SQLRegionDatabase.saveChanges(SQLRegionDatabase.java:270) ~[worldguard-legacy-7.0.0-SNAPSHOT-dist.jar:?]
        at com.sk89q.worldguard.protection.managers.RegionManager.saveChanges(RegionManager.java:135) ~[worldguard-legacy-7.0.0-SNAPSHOT-dist.jar:?]
        at com.sk89q.worldguard.protection.managers.RegionContainerImpl$BackgroundSaver.run(RegionContainerImpl.java:228) [worldguard-legacy-7.0.0-SNAPSHOT-dist.jar:?]
        at java.util.TimerThread.mainLoop(Timer.java:556) [?:?]
        at java.util.TimerThread.run(Timer.java:506) [?:?]
Caused by: java.sql.BatchUpdateException: Data truncation: Data too long for column 'value' at row 1
        at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:?]
        at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62) ~[?:?]
        at jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:?]
        at java.lang.reflect.Constructor.newInstance(Constructor.java:488) ~[?:?]
        at com.mysql.jdbc.Util.handleNewInstance(Util.java:425) ~[spigot-latest.jar:git-Spigot-fe3ab0d-bfb9131]
        at com.mysql.jdbc.Util.getInstance(Util.java:408) ~[spigot-latest.jar:git-Spigot-fe3ab0d-bfb9131]
        at com.mysql.jdbc.SQLError.createBatchUpdateException(SQLError.java:1163) ~[spigot-latest.jar:git-Spigot-fe3ab0d-bfb9131]
        at com.mysql.jdbc.PreparedStatement.executeBatchSerially(PreparedStatement.java:1778) ~[spigot-latest.jar:git-Spigot-fe3ab0d-bfb9131]
        at com.mysql.jdbc.PreparedStatement.executeBatchInternal(PreparedStatement.java:1262) ~[spigot-latest.jar:git-Spigot-fe3ab0d-bfb9131]
        at com.mysql.jdbc.StatementImpl.executeBatch(StatementImpl.java:970) ~[spigot-latest.jar:git-Spigot-fe3ab0d-bfb9131]
        at com.sk89q.worldguard.protection.managers.storage.sql.StatementBatch.executeRemaining(StatementBatch.java:50) ~[?:?]
        at com.sk89q.worldguard.protection.managers.storage.sql.RegionUpdater.replaceFlags(RegionUpdater.java:170) ~[?:?]
        at com.sk89q.worldguard.protection.managers.storage.sql.RegionUpdater.apply(RegionUpdater.java:331) ~[?:?]
        at com.sk89q.worldguard.protection.managers.storage.sql.DataUpdater.executeSave(DataUpdater.java:130) ~[?:?]
        at com.sk89q.worldguard.protection.managers.storage.sql.DataUpdater.saveChanges(DataUpdater.java:73) ~[?:?]
        at com.sk89q.worldguard.protection.managers.storage.sql.SQLRegionDatabase.saveChanges(SQLRegionDatabase.java:268) ~[?:?]
        ... 4 more
Caused by: com.mysql.jdbc.MysqlDataTruncation: Data truncation: Data too long for column 'value' at row 1
        at com.mysql.jdbc.MysqlIO.checkErrorPacket(MysqlIO.java:3974) ~[spigot-latest.jar:git-Spigot-fe3ab0d-bfb9131]
        at com.mysql.jdbc.MysqlIO.checkErrorPacket(MysqlIO.java:3912) ~[spigot-latest.jar:git-Spigot-fe3ab0d-bfb9131]
        at com.mysql.jdbc.MysqlIO.sendCommand(MysqlIO.java:2530) ~[spigot-latest.jar:git-Spigot-fe3ab0d-bfb9131]
        at com.mysql.jdbc.MysqlIO.sqlQueryDirect(MysqlIO.java:2683) ~[spigot-latest.jar:git-Spigot-fe3ab0d-bfb9131]
        at com.mysql.jdbc.ConnectionImpl.execSQL(ConnectionImpl.java:2486) ~[spigot-latest.jar:git-Spigot-fe3ab0d-bfb9131]
        at com.mysql.jdbc.PreparedStatement.executeInternal(PreparedStatement.java:1858) ~[spigot-latest.jar:git-Spigot-fe3ab0d-bfb9131]
        at com.mysql.jdbc.PreparedStatement.executeUpdateInternal(PreparedStatement.java:2079) ~[spigot-latest.jar:git-Spigot-fe3ab0d-bfb9131]
        at com.mysql.jdbc.PreparedStatement.executeBatchSerially(PreparedStatement.java:1756) ~[spigot-latest.jar:git-Spigot-fe3ab0d-bfb9131]
        at com.mysql.jdbc.PreparedStatement.executeBatchInternal(PreparedStatement.java:1262) ~[spigot-latest.jar:git-Spigot-fe3ab0d-bfb9131]
        at com.mysql.jdbc.StatementImpl.executeBatch(StatementImpl.java:970) ~[spigot-latest.jar:git-Spigot-fe3ab0d-bfb9131]
        at com.sk89q.worldguard.protection.managers.storage.sql.StatementBatch.executeRemaining(StatementBatch.java:50) ~[?:?]
        at com.sk89q.worldguard.protection.managers.storage.sql.RegionUpdater.replaceFlags(RegionUpdater.java:170) ~[?:?]
        at com.sk89q.worldguard.protection.managers.storage.sql.RegionUpdater.apply(RegionUpdater.java:331) ~[?:?]
        at com.sk89q.worldguard.protection.managers.storage.sql.DataUpdater.executeSave(DataUpdater.java:130) ~[?:?]
        at com.sk89q.worldguard.protection.managers.storage.sql.DataUpdater.saveChanges(DataUpdater.java:73) ~[?:?]
        at com.sk89q.worldguard.protection.managers.storage.sql.SQLRegionDatabase.saveChanges(SQLRegionDatabase.java:268) ~[?:?]
        ... 4 more
```