### PR TITLE
Delay ProcessPlayerEvent by one tick on bukkit onEnable 

### DIFF
--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPlugin.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/WorldGuardPlugin.java
@@ -212,10 +212,12 @@ public class WorldGuardPlugin extends JavaPlugin {
         }
         worldListener.registerEvents();
 
-        for (Player player : Bukkit.getServer().getOnlinePlayers()) {
-            ProcessPlayerEvent event = new ProcessPlayerEvent(player);
-            Events.fire(event);
-        }
+        Bukkit.getScheduler().runTask(this, () -> {
+            for (Player player : Bukkit.getServer().getOnlinePlayers()) {
+                ProcessPlayerEvent event = new ProcessPlayerEvent(player);
+                Events.fire(event);
+            }
+        });
 
         ((SimpleFlagRegistry) WorldGuard.getInstance().getFlagRegistry()).setInitialized(true);
     }


### PR DESCRIPTION
This change allow other plugin to register their Handlers on existing player when /reload the server.

When /reload the server, WorldGuard create Sessions for online players by firing ProcessPlayerEvent in onEnable. But other plugin that want to register their Handles is not enabled yet (because they need to depend on WorldGuard). So existing player will bypass other plugin's Handle for this session.

If we delay ProcessPlayerEvents by one tick, we can ensure all plugin are enabled and registered before creating Sessions for online players.