### PR TITLE
Fix NPE in WorldGuardPlugin.wrapOfflinePlayer()

### DIFF
--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/BukkitPlayer.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/BukkitPlayer.java
@@ -41,7 +41,7 @@ public class BukkitPlayer extends com.sk89q.worldedit.bukkit.BukkitPlayer implem
         super((WorldEditPlugin) Bukkit.getPluginManager().getPlugin("WorldEdit"), player);
         this.plugin = plugin;
         // getName() takes longer than before in newer versions of Minecraft
-        this.name = player.getName();
+        this.name = player == null ? null : player.getName();
         this.silenced = silenced;
     }
 


### PR DESCRIPTION
The constructor of BukkitOfflinePlayer calls the constructor of BukkitPlayer with a null player. So without this fix it is not possible to create any BukkitOfflinePlayer.